### PR TITLE
Recover shebang, encoding declaration and non-ascii chars in author name

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 from conans import ConanFile
 
 
@@ -5,7 +8,7 @@ class CtreConan(ConanFile):
     name = "CTRE"
     license = "MIT"
     url = "https://github.com/hanickadot/compile-time-regular-expressions"
-    author = "Hana Dusikova (ctre@hanicka.net)"
+    author = "Hana Dusíková (ctre@hanicka.net)"
     description = "Compile Time Regular Expression for C++17/20"
     homepage = "https://github.com/hanickadot/compile-time-regular-expressions"
     no_copy_source = True


### PR DESCRIPTION
Conan v1.8.3 has just been released, including https://github.com/conan-io/conan/pull/3750 that solves the issue reported by @hanickadot. 🎉  🎉 

