### PR TITLE
Update CMakeLists.txt for better usability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,35 +1,95 @@
 cmake_minimum_required(VERSION 3.8.0)
-project(compile-time-regular-expressions VERSION 2.6.4 LANGUAGES CXX)
+# When updating to a newer version of CMake, see if we can use the following
+project(ctre
+  #HOMEPAGE_URL "https://compile-time.re"
+  #DESCRIPTION "A Compile time PCRE compatible regular expression matcher"
+  VERSION 2.6.4
+  LANGUAGES CXX)
 
-add_library(ctre INTERFACE)
-add_library(ctre::ctre ALIAS ctre)
-target_include_directories(ctre INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>)
+include(CMakePackageConfigHelpers)
+include(CMakeDependentOption)
+include(GNUInstallDirs)
+include(CTest)
+
+find_program(CTRE_DPKG_BUILDPACKAGE_FOUND dpkg-buildpackage)
+find_program(CTRE_RPMBUILD_FOUND rpmbuild)
+
+cmake_dependent_option(CTRE_BUILD_TESTS "Build ctre Tests" ON
+  "BUILD_TESTING;CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF)
+cmake_dependent_option(CTRE_BUILD_PACKAGE "Build ctre Packages" ON
+  "CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF)
+cmake_dependent_option(CTRE_BUILD_PACKAGE_DEB
+  "Create DEB Package (${PROJECT_NAME})" ON
+  "CTRE_BUILD_PACKAGE;CTRE_DPKG_BUILDPACKAGE_FOUND" OFF)
+cmake_dependent_option(CTRE_BUILD_PACKAGE_RPM
+  "Create RPM Package (${PROJECT_NAME})" ON
+  "CTRE_BUILD_PACKAGE;CTRE_RPMBUILD_FOUND" OFF)
+
+add_library(${PROJECT_NAME} INTERFACE)
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+
+target_include_directories(${PROJECT_NAME} INTERFACE
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
 target_compile_features(ctre INTERFACE cxx_std_17)
 
-install(TARGETS ctre EXPORT ctre-targets)
+install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}-targets)
 
-export(EXPORT ctre-targets NAMESPACE ctre::)
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/ctre-config.cmake
-    "include(\${CMAKE_CURRENT_LIST_DIR}/ctre-targets.cmake)")
-include(CMakePackageConfigHelpers)
+if (NOT EXISTS "${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config.cmake.in")
+  file(WRITE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config.cmake.in [[
+    @PACKAGE_INIT@
+    include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
+  ]])
+endif()
+
+configure_package_config_file(
+  "${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config.cmake.in"
+  "${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+  INSTALL_DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}"
+  NO_SET_AND_CHECK_MACRO
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+
 write_basic_package_version_file(ctre-config-version.cmake
-    VERSION ${ctre_VERSION}
-    COMPATIBILITY SameMajorVersion)
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY SameMajorVersion)
 
-install(EXPORT ctre-targets DESTINATION lib/cmake/ctre
-    NAMESPACE ctre::)
+install(EXPORT ${PROJECT_NAME}-targets 
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}"
+  NAMESPACE ${PROJECT_NAME}::)
 install(
-    FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/ctre-config.cmake
-        ${CMAKE_CURRENT_BINARY_DIR}/ctre-config-version.cmake
-    DESTINATION lib/cmake/ctre)
+  FILES
+    "${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
+    "${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME})
 install(DIRECTORY include/ DESTINATION include
     FILES_MATCHING PATTERN *.hpp)
 
-option(ENABLE_CTRE_SELF_TEST "build self tests" OFF)
-
-if(ENABLE_CTRE_SELF_TEST)
-add_subdirectory(tests)
+if(CTRE_BUILD_TESTS)
+  add_subdirectory(tests)
 endif()
+
+if (NOT CTRE_BUILD_PACKAGE)
+  return()
+endif()
+
+list(APPEND source-generators TBZ2 TGZ TXZ ZIP)
+
+if (CTRE_BUILD_PACKAGE_DEB)
+  list(APPEND binary-generators "DEB")
+endif()
+
+if (CTRE_BUILD_PACKAGE_RPM)
+  list(APPEND binary-generators "RPM")
+endif()
+
+set(CPACK_SOURCE_GENERATOR ${source-generators})
+set(CPACK_GENERATOR ${binary-generators})
+
+set(CPACK_PACKAGE_FILE_NAME "${PROJECT_NAME}-${PROJECT_VERSION}")
+set(CPACK_SOURCE_PACKAGE_FILE_NAME "${CPACK_PACKAGE_FILE_NAME}")
+
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Hanicka Dusíková")
+
+list(APPEND CPACK_SOURCE_IGNORE_FILES /.git/ /build/ .gitignore .DS_Store)
+
+include(CPack)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,14 +1,10 @@
-file(GLOB ctre_self_tests *.cpp)
+file(GLOB test-sources CONFIGURE_DEPENDS *.cpp)
 
-add_custom_target(ctre_self_test)
+add_custom_target(ctre-test)
 
-foreach(ctre_self_test_file ${ctre_self_tests})
-	get_filename_component(ctre_self_test_name ${ctre_self_test_file} NAME)
-	message(STATUS ${ctre_self_test_name})
-	
-	add_library(ctre_self_test_${ctre_self_test_name} STATIC ${ctre_self_test_name})
-	target_link_libraries(ctre_self_test_${ctre_self_test_name} ctre)
-	target_compile_features(ctre_self_test_${ctre_self_test_name} PRIVATE cxx_std_17)
-	
-	add_dependencies(ctre_self_test ctre_self_test_${ctre_self_test_name})
+foreach (source IN LISTS test-sources)
+  get_filename_component(test "${source}" NAME_WE)
+  add_library(ctre-test-${test} STATIC EXCLUDE_FROM_ALL ${source})
+  target_link_libraries(ctre-test-${test} PRIVATE ctre)
+  add_dependencies(ctre-test ctre-test-${test})
 endforeach()


### PR DESCRIPTION
:recycle: Refactor CMake for a more "modern" approach
:package: Add support for generating a .deb file

This change changes the project-name to CTRE (which is what it exports as a library name).
The call to `export()` has been removed as this call no longer works in newer CMake versions, and its use is discouraged

Install location for cmake related files has been updated to use CMAKE_INSTALL_DATADIR to be in step with other CMake projects and to follow best practices.

Tests are also marked `EXCLUDE_FROM_ALL`, so you need to manually call `ctre-tests` to build the unit tests. In the future, I'd recommend looking into using Catch2, even for static asserts, so that `add_test` can be used.

`BUILD_TESTING` and CTest are now included (but CTest is not used). If the project is being built "stand alone" (that is, not via `add_subdirectory`), tests are automatically enabled, but not automatically built. 

Package targets are also automatically enabled.

More work is needed for RPM support, BUT I don't have access to a machine like that so oh well :v