### PR TITLE
Parse Support (search only from start)

### DIFF
--- a/include/ctre/evaluation.hpp
+++ b/include/ctre/evaluation.hpp
@@ -40,6 +40,12 @@ constexpr inline auto search_re(const Iterator begin, const EndIterator end, Pat
 	return evaluate(begin, it, end, return_type{}, ctll::list<start_mark, Pattern, end_mark, accept>());
 }
 
+template <typename Iterator, typename EndIterator, typename Pattern>
+constexpr inline auto parse_re(const Iterator begin, const EndIterator end, Pattern pattern) noexcept {
+	using return_type = decltype(regex_results(std::declval<Iterator>(), find_captures(pattern)));
+	return evaluate(begin, begin, end, return_type{}, ctll::list<start_mark, Pattern, end_mark, accept>());
+}
+
 
 // sink for making the errors shorter
 template <typename R, typename Iterator, typename EndIterator> 

--- a/include/ctre/functions.hpp
+++ b/include/ctre/functions.hpp
@@ -66,6 +66,16 @@ template <typename RE> struct regex_search_t {
 	}
 };
 
+template <typename RE> struct regex_parse_t {
+	template <typename... Args> CTRE_FORCE_INLINE constexpr auto operator()(Args&& ... args) const noexcept {
+		auto re_obj = ctre::regular_expression<RE>();
+		return re_obj.parse(std::forward<Args>(args)...);
+	}
+	template <typename... Args> CTRE_FORCE_INLINE constexpr auto try_extract(Args&& ... args) const noexcept {
+		return operator()(std::forward<Args>(args)...);
+	}
+};
+
 #if __cpp_nontype_template_parameter_class
 
 template <auto input> struct regex_builder {
@@ -90,6 +100,8 @@ template <auto & input> struct regex_builder {
 template <auto & input> static constexpr inline auto match = regex_match_t<typename regex_builder<input>::type>();
 
 template <auto & input> static constexpr inline auto search = regex_search_t<typename regex_builder<input>::type>();
+
+template <auto & input> static constexpr inline auto search = regex_parse_t<typename regex_builder<input>::type>();
 
 #endif
 

--- a/include/ctre/wrapper.hpp
+++ b/include/ctre/wrapper.hpp
@@ -38,6 +38,9 @@ template <typename RE> struct regular_expression {
 	template <typename IteratorBegin, typename IteratorEnd> constexpr CTRE_FORCE_INLINE static auto search_2(IteratorBegin begin, IteratorEnd end) noexcept {
 		return search_re(begin, end, RE());
 	}
+	template <typename IteratorBegin, typename IteratorEnd> constexpr CTRE_FORCE_INLINE static auto parse_2(IteratorBegin begin, IteratorEnd end) noexcept {
+		return parse_re(begin, end, RE());
+	}
 	constexpr CTRE_FORCE_INLINE regular_expression() noexcept { }
 	constexpr CTRE_FORCE_INLINE regular_expression(RE) noexcept { }
 	template <typename Iterator> constexpr CTRE_FORCE_INLINE static auto match(Iterator begin, Iterator end) noexcept {
@@ -99,6 +102,36 @@ template <typename RE> struct regular_expression {
 	}
 	template <typename Range> static constexpr CTRE_FORCE_INLINE auto search(Range && range) noexcept {
 		return search(std::begin(range), std::end(range));
+	}
+	template <typename Iterator> constexpr CTRE_FORCE_INLINE static auto parse(Iterator begin, Iterator end) noexcept {
+		return parse_re(begin, end, RE());
+	}
+	constexpr CTRE_FORCE_INLINE static auto parse(const char* s) noexcept {
+		return parse_2(s, zero_terminated_string_end_iterator());
+	}
+	static constexpr CTRE_FORCE_INLINE auto parse(const wchar_t* s) noexcept {
+		return parse_2(s, zero_terminated_string_end_iterator());
+	}
+	static constexpr CTRE_FORCE_INLINE auto parse(const std::string& s) noexcept {
+		return parse_2(s.c_str(), zero_terminated_string_end_iterator());
+	}
+	static constexpr CTRE_FORCE_INLINE auto parse(const std::wstring& s) noexcept {
+		return parse_2(s.c_str(), zero_terminated_string_end_iterator());
+	}
+	static constexpr CTRE_FORCE_INLINE auto parse(std::string_view sv) noexcept {
+		return parse(sv.begin(), sv.end());
+	}
+	static constexpr CTRE_FORCE_INLINE auto parse(std::wstring_view sv) noexcept {
+		return parse(sv.begin(), sv.end());
+	}
+	static constexpr CTRE_FORCE_INLINE auto parse(std::u16string_view sv) noexcept {
+		return parse(sv.begin(), sv.end());
+	}
+	static constexpr CTRE_FORCE_INLINE auto parse(std::u32string_view sv) noexcept {
+		return parse(sv.begin(), sv.end());
+	}
+	template <typename Range> static constexpr CTRE_FORCE_INLINE auto parse(Range&& range) noexcept {
+		return parse(std::begin(range), std::end(range));
 	}
 };
 


### PR DESCRIPTION
Adds "parse" function, which is equivalent to searching only from
the beginning of the input.

EG. Where
match performs `^(pattern)$`
search performs `[\s\S]*(pattern)[\s\S]*`
parse performs `^(pattern)[\s\S]*`

Handy for lexxing tokens.