### PR TITLE
Make uses python3 instead of python3.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,9 +63,9 @@ single-header: single-header/ctre.hpp
 
 single-header/ctre.hpp:
 	python3 -m quom include/ctre.hpp ctre.hpp.tmp
-	echo "/*\n" > single-header/ctre.hpp
+	echo "/*" > single-header/ctre.hpp
 	cat LICENSE >> single-header/ctre.hpp
-	echo "\n*/\n" >> single-header/ctre.hpp 
+	echo "*/" >> single-header/ctre.hpp
 	cat ctre.hpp.tmp >> single-header/ctre.hpp
 	rm ctre.hpp.tmp
 	

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ mtent12.txt: mtent12.zip
 single-header: single-header/ctre.hpp
 
 single-header/ctre.hpp:
-	python3.7 -m quom include/ctre.hpp ctre.hpp.tmp
+	python3 -m quom include/ctre.hpp ctre.hpp.tmp
 	echo "/*\n" > single-header/ctre.hpp
 	cat LICENSE >> single-header/ctre.hpp
 	echo "\n*/\n" >> single-header/ctre.hpp 


### PR DESCRIPTION
Removes dependency on a specific python interpreter