### PR TITLE
fix signed comparison warning.

### DIFF
--- a/include/ctll/parser.hpp
+++ b/include/ctll/parser.hpp
@@ -26,7 +26,7 @@ template <typename Grammar, ctll::fixed_string input, typename ActionSelector = 
 #else
 template <typename Grammar, const auto & input, typename ActionSelector = empty_actions, bool IgnoreUnknownActions = false> struct parser {
 #endif
-
+	
 	#ifdef __GNUC__ // workaround to GCC bug
 		#if ((__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L)) || (__cpp_nontype_template_args >= 201911L))
 		static constexpr auto _input = input;  // c++20 mode
@@ -39,12 +39,12 @@ template <typename Grammar, const auto & input, typename ActionSelector = empty_
 
 	using Actions = ctll::conditional<IgnoreUnknownActions, ignore_unknown<ActionSelector>, identity<ActionSelector>>;
 	using grammar = augment_grammar<Grammar>;
-
+	
 	template <size_t Pos, typename Stack, typename Subject, decision Decision> struct results {
 		constexpr inline CTLL_FORCE_INLINE operator bool() const noexcept {
 			return Decision == decision::accept;
 		}
-
+		
 		#ifdef __GNUC__ // workaround to GCC bug
 			#if ((__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L)) || (__cpp_nontype_template_args >= 201911L))
 			static constexpr auto _input = input;  // c++20 mode
@@ -54,9 +54,9 @@ template <typename Grammar, const auto & input, typename ActionSelector = empty_
 		#else
 			static constexpr auto _input = input; // everyone else
 		#endif
-
+	
 		using output_type = Subject;
-
+    
 		constexpr auto operator+(placeholder) const noexcept {
 			if constexpr (Decision == decision::undecided) {
 				// parse for current char (RPos) with previous stack and subject :)
@@ -67,7 +67,7 @@ template <typename Grammar, const auto & input, typename ActionSelector = empty_
 			}
 		}
 	};
-
+	
 	template <size_t Pos> static constexpr auto get_current_term() noexcept {
 		if constexpr (Pos < input.size()) {
 			constexpr auto value = input[Pos];
@@ -76,7 +76,7 @@ template <typename Grammar, const auto & input, typename ActionSelector = empty_
 			} else {
 				return term<value>{};
 			}
-
+			
 		} else {
 			// return epsilon if we are past the input
 			return epsilon{};
@@ -98,7 +98,7 @@ template <typename Grammar, const auto & input, typename ActionSelector = empty_
 		}
 	}
 	// if rule is accept => return true and subject
-	template <size_t Pos, typename Terminal, typename Stack, typename Subject>
+	template <size_t Pos, typename Terminal, typename Stack, typename Subject> 
 	static constexpr auto move(ctll::accept, Terminal, Stack, Subject) noexcept {
 		return typename parser<Grammar, _input, ActionSelector, IgnoreUnknownActions>::template results<Pos, Stack, Subject, decision::accept>();
 	}
@@ -122,14 +122,14 @@ template <typename Grammar, const auto & input, typename ActionSelector = empty_
 	static constexpr auto move(epsilon, Terminal, Stack stack, Subject subject) noexcept {
 		return decide<Pos>(stack, subject);
 	}
-	// if rule is string with current character at the beginning (term<V>) => move to next character
+	// if rule is string with current character at the beginning (term<V>) => move to next character 
 	// and push string without the character (quick LL(1))
 	template <size_t Pos, auto V, typename... Content, typename Stack, typename Subject>
 	static constexpr auto move(push<term<V>, Content...>, term<V>, Stack stack, Subject) noexcept {
 		constexpr auto _input = input;
 		return typename parser<Grammar, _input, ActionSelector, IgnoreUnknownActions>::template results<Pos+1, decltype(push_front(list<Content...>(), stack)), Subject, decision::undecided>();
 	}
-	// if rule is string with any character at the beginning (compatible with current term<T>) => move to next character
+	// if rule is string with any character at the beginning (compatible with current term<T>) => move to next character 
 	// and push string without the character (quick LL(1))
 	template <size_t Pos, auto V, typename... Content, auto T, typename Stack, typename Subject>
 	static constexpr auto move(push<anything, Content...>, term<T>, Stack stack, Subject) noexcept {
@@ -142,11 +142,11 @@ template <typename Grammar, const auto & input, typename ActionSelector = empty_
 		auto top_symbol = decltype(ctll::front(previous_stack, empty_stack_symbol()))();
 		// gcc pedantic warning
 		[[maybe_unused]] auto stack = decltype(ctll::pop_front(previous_stack))();
-
+		
 		// in case top_symbol is action type (apply it on previous subject and get new one)
 		if constexpr (std::is_base_of_v<ctll::action, decltype(top_symbol)>) {
 			auto subject = Actions::apply(top_symbol, get_previous_term<Pos>(), previous_subject);
-
+			
 			// in case that semantic action is error => reject input
 			if constexpr (std::is_same_v<ctll::reject, decltype(subject)>) {
 				return typename parser<Grammar, _input, ActionSelector, IgnoreUnknownActions>::template results<Pos, Stack, Subject, decision::reject>();
@@ -160,7 +160,7 @@ template <typename Grammar, const auto & input, typename ActionSelector = empty_
 			return move<Pos>(rule, current_term, stack, previous_subject);
 		}
 	}
-
+	
 	// trampolines with folded expression
 	template <typename Subject, size_t... Pos> static constexpr auto trampoline_decide(Subject, std::index_sequence<Pos...>) noexcept {
 		// parse everything for first char and than for next and next ...
@@ -168,12 +168,12 @@ template <typename Grammar, const auto & input, typename ActionSelector = empty_
 		auto v = (decide<0, typename grammar::start_stack, Subject>({}, {}) + ... + index_placeholder<Pos+1>());
 		return v;
 	}
-
+	
 	template <typename Subject = empty_subject> static constexpr auto trampoline_decide(Subject subject = {}) noexcept {
 		// there will be no recursion, just sequence long as the input
 		return trampoline_decide(subject, std::make_index_sequence<input.size()>());
 	}
-
+	
 	template <typename Subject = empty_subject> using output = decltype(trampoline_decide<Subject>());
 	template <typename Subject = empty_subject> static inline constexpr bool correct_with = trampoline_decide<Subject>();
 
@@ -183,3 +183,4 @@ template <typename Grammar, const auto & input, typename ActionSelector = empty_
 
 
 #endif
+

--- a/include/ctll/parser.hpp
+++ b/include/ctll/parser.hpp
@@ -26,7 +26,7 @@ template <typename Grammar, ctll::fixed_string input, typename ActionSelector = 
 #else
 template <typename Grammar, const auto & input, typename ActionSelector = empty_actions, bool IgnoreUnknownActions = false> struct parser {
 #endif
-	
+
 	#ifdef __GNUC__ // workaround to GCC bug
 		#if ((__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L)) || (__cpp_nontype_template_args >= 201911L))
 		static constexpr auto _input = input;  // c++20 mode
@@ -39,12 +39,12 @@ template <typename Grammar, const auto & input, typename ActionSelector = empty_
 
 	using Actions = ctll::conditional<IgnoreUnknownActions, ignore_unknown<ActionSelector>, identity<ActionSelector>>;
 	using grammar = augment_grammar<Grammar>;
-	
+
 	template <size_t Pos, typename Stack, typename Subject, decision Decision> struct results {
 		constexpr inline CTLL_FORCE_INLINE operator bool() const noexcept {
 			return Decision == decision::accept;
 		}
-		
+
 		#ifdef __GNUC__ // workaround to GCC bug
 			#if ((__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L)) || (__cpp_nontype_template_args >= 201911L))
 			static constexpr auto _input = input;  // c++20 mode
@@ -54,9 +54,9 @@ template <typename Grammar, const auto & input, typename ActionSelector = empty_
 		#else
 			static constexpr auto _input = input; // everyone else
 		#endif
-	
+
 		using output_type = Subject;
-    
+
 		constexpr auto operator+(placeholder) const noexcept {
 			if constexpr (Decision == decision::undecided) {
 				// parse for current char (RPos) with previous stack and subject :)
@@ -67,16 +67,16 @@ template <typename Grammar, const auto & input, typename ActionSelector = empty_
 			}
 		}
 	};
-	
+
 	template <size_t Pos> static constexpr auto get_current_term() noexcept {
 		if constexpr (Pos < input.size()) {
 			constexpr auto value = input[Pos];
-			if constexpr (value <= std::numeric_limits<char>::max()) {
+			if constexpr (value <= static_cast<decltype(value)>(std::numeric_limits<char>::max())) {
 				return term<static_cast<char>(value)>{};
 			} else {
-				return term<input[Pos]>{};
+				return term<value>{};
 			}
-			
+
 		} else {
 			// return epsilon if we are past the input
 			return epsilon{};
@@ -88,7 +88,7 @@ template <typename Grammar, const auto & input, typename ActionSelector = empty_
 			return epsilon{};
 		} else if constexpr ((Pos-1) < input.size()) {
 			constexpr auto value = input[Pos-1];
-			if constexpr (value <= std::numeric_limits<char>::max()) {
+			if constexpr (value <= static_cast<decltype(value)>(std::numeric_limits<char>::max())) {
 				return term<static_cast<char>(value)>{};
 			} else {
 				return term<value>{};
@@ -98,7 +98,7 @@ template <typename Grammar, const auto & input, typename ActionSelector = empty_
 		}
 	}
 	// if rule is accept => return true and subject
-	template <size_t Pos, typename Terminal, typename Stack, typename Subject> 
+	template <size_t Pos, typename Terminal, typename Stack, typename Subject>
 	static constexpr auto move(ctll::accept, Terminal, Stack, Subject) noexcept {
 		return typename parser<Grammar, _input, ActionSelector, IgnoreUnknownActions>::template results<Pos, Stack, Subject, decision::accept>();
 	}
@@ -122,14 +122,14 @@ template <typename Grammar, const auto & input, typename ActionSelector = empty_
 	static constexpr auto move(epsilon, Terminal, Stack stack, Subject subject) noexcept {
 		return decide<Pos>(stack, subject);
 	}
-	// if rule is string with current character at the beginning (term<V>) => move to next character 
+	// if rule is string with current character at the beginning (term<V>) => move to next character
 	// and push string without the character (quick LL(1))
 	template <size_t Pos, auto V, typename... Content, typename Stack, typename Subject>
 	static constexpr auto move(push<term<V>, Content...>, term<V>, Stack stack, Subject) noexcept {
 		constexpr auto _input = input;
 		return typename parser<Grammar, _input, ActionSelector, IgnoreUnknownActions>::template results<Pos+1, decltype(push_front(list<Content...>(), stack)), Subject, decision::undecided>();
 	}
-	// if rule is string with any character at the beginning (compatible with current term<T>) => move to next character 
+	// if rule is string with any character at the beginning (compatible with current term<T>) => move to next character
 	// and push string without the character (quick LL(1))
 	template <size_t Pos, auto V, typename... Content, auto T, typename Stack, typename Subject>
 	static constexpr auto move(push<anything, Content...>, term<T>, Stack stack, Subject) noexcept {
@@ -142,11 +142,11 @@ template <typename Grammar, const auto & input, typename ActionSelector = empty_
 		auto top_symbol = decltype(ctll::front(previous_stack, empty_stack_symbol()))();
 		// gcc pedantic warning
 		[[maybe_unused]] auto stack = decltype(ctll::pop_front(previous_stack))();
-		
+
 		// in case top_symbol is action type (apply it on previous subject and get new one)
 		if constexpr (std::is_base_of_v<ctll::action, decltype(top_symbol)>) {
 			auto subject = Actions::apply(top_symbol, get_previous_term<Pos>(), previous_subject);
-			
+
 			// in case that semantic action is error => reject input
 			if constexpr (std::is_same_v<ctll::reject, decltype(subject)>) {
 				return typename parser<Grammar, _input, ActionSelector, IgnoreUnknownActions>::template results<Pos, Stack, Subject, decision::reject>();
@@ -160,7 +160,7 @@ template <typename Grammar, const auto & input, typename ActionSelector = empty_
 			return move<Pos>(rule, current_term, stack, previous_subject);
 		}
 	}
-	
+
 	// trampolines with folded expression
 	template <typename Subject, size_t... Pos> static constexpr auto trampoline_decide(Subject, std::index_sequence<Pos...>) noexcept {
 		// parse everything for first char and than for next and next ...
@@ -168,12 +168,12 @@ template <typename Grammar, const auto & input, typename ActionSelector = empty_
 		auto v = (decide<0, typename grammar::start_stack, Subject>({}, {}) + ... + index_placeholder<Pos+1>());
 		return v;
 	}
-	
+
 	template <typename Subject = empty_subject> static constexpr auto trampoline_decide(Subject subject = {}) noexcept {
 		// there will be no recursion, just sequence long as the input
 		return trampoline_decide(subject, std::make_index_sequence<input.size()>());
 	}
-	
+
 	template <typename Subject = empty_subject> using output = decltype(trampoline_decide<Subject>());
 	template <typename Subject = empty_subject> static inline constexpr bool correct_with = trampoline_decide<Subject>();
 
@@ -183,4 +183,3 @@ template <typename Grammar, const auto & input, typename ActionSelector = empty_
 
 
 #endif
-

--- a/single-header/ctre.hpp
+++ b/single-header/ctre.hpp
@@ -692,7 +692,7 @@ template <typename Grammar, ctll::fixed_string input, typename ActionSelector = 
 #else
 template <typename Grammar, const auto & input, typename ActionSelector = empty_actions, bool IgnoreUnknownActions = false> struct parser {
 #endif
-	
+
 	#ifdef __GNUC__ // workaround to GCC bug
 		#if ((__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L)) || (__cpp_nontype_template_args >= 201911L))
 		static constexpr auto _input = input;  // c++20 mode
@@ -705,12 +705,12 @@ template <typename Grammar, const auto & input, typename ActionSelector = empty_
 
 	using Actions = ctll::conditional<IgnoreUnknownActions, ignore_unknown<ActionSelector>, identity<ActionSelector>>;
 	using grammar = augment_grammar<Grammar>;
-	
+
 	template <size_t Pos, typename Stack, typename Subject, decision Decision> struct results {
 		constexpr inline CTLL_FORCE_INLINE operator bool() const noexcept {
 			return Decision == decision::accept;
 		}
-		
+
 		#ifdef __GNUC__ // workaround to GCC bug
 			#if ((__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L)) || (__cpp_nontype_template_args >= 201911L))
 			static constexpr auto _input = input;  // c++20 mode
@@ -720,9 +720,9 @@ template <typename Grammar, const auto & input, typename ActionSelector = empty_
 		#else
 			static constexpr auto _input = input; // everyone else
 		#endif
-	
+
 		using output_type = Subject;
-    
+
 		constexpr auto operator+(placeholder) const noexcept {
 			if constexpr (Decision == decision::undecided) {
 				// parse for current char (RPos) with previous stack and subject :)
@@ -733,16 +733,16 @@ template <typename Grammar, const auto & input, typename ActionSelector = empty_
 			}
 		}
 	};
-	
+
 	template <size_t Pos> static constexpr auto get_current_term() noexcept {
 		if constexpr (Pos < input.size()) {
 			constexpr auto value = input[Pos];
-			if constexpr (value <= std::numeric_limits<char>::max()) {
+			if constexpr (value <= static_cast<decltype(value)>(std::numeric_limits<char>::max())) {
 				return term<static_cast<char>(value)>{};
 			} else {
-				return term<input[Pos]>{};
+				return term<value>{};
 			}
-			
+
 		} else {
 			// return epsilon if we are past the input
 			return epsilon{};
@@ -754,7 +754,7 @@ template <typename Grammar, const auto & input, typename ActionSelector = empty_
 			return epsilon{};
 		} else if constexpr ((Pos-1) < input.size()) {
 			constexpr auto value = input[Pos-1];
-			if constexpr (value <= std::numeric_limits<char>::max()) {
+			if constexpr (value <= static_cast<decltype(value)>(std::numeric_limits<char>::max())) {
 				return term<static_cast<char>(value)>{};
 			} else {
 				return term<value>{};
@@ -764,7 +764,7 @@ template <typename Grammar, const auto & input, typename ActionSelector = empty_
 		}
 	}
 	// if rule is accept => return true and subject
-	template <size_t Pos, typename Terminal, typename Stack, typename Subject> 
+	template <size_t Pos, typename Terminal, typename Stack, typename Subject>
 	static constexpr auto move(ctll::accept, Terminal, Stack, Subject) noexcept {
 		return typename parser<Grammar, _input, ActionSelector, IgnoreUnknownActions>::template results<Pos, Stack, Subject, decision::accept>();
 	}
@@ -788,14 +788,14 @@ template <typename Grammar, const auto & input, typename ActionSelector = empty_
 	static constexpr auto move(epsilon, Terminal, Stack stack, Subject subject) noexcept {
 		return decide<Pos>(stack, subject);
 	}
-	// if rule is string with current character at the beginning (term<V>) => move to next character 
+	// if rule is string with current character at the beginning (term<V>) => move to next character
 	// and push string without the character (quick LL(1))
 	template <size_t Pos, auto V, typename... Content, typename Stack, typename Subject>
 	static constexpr auto move(push<term<V>, Content...>, term<V>, Stack stack, Subject) noexcept {
 		constexpr auto _input = input;
 		return typename parser<Grammar, _input, ActionSelector, IgnoreUnknownActions>::template results<Pos+1, decltype(push_front(list<Content...>(), stack)), Subject, decision::undecided>();
 	}
-	// if rule is string with any character at the beginning (compatible with current term<T>) => move to next character 
+	// if rule is string with any character at the beginning (compatible with current term<T>) => move to next character
 	// and push string without the character (quick LL(1))
 	template <size_t Pos, auto V, typename... Content, auto T, typename Stack, typename Subject>
 	static constexpr auto move(push<anything, Content...>, term<T>, Stack stack, Subject) noexcept {
@@ -808,11 +808,11 @@ template <typename Grammar, const auto & input, typename ActionSelector = empty_
 		auto top_symbol = decltype(ctll::front(previous_stack, empty_stack_symbol()))();
 		// gcc pedantic warning
 		[[maybe_unused]] auto stack = decltype(ctll::pop_front(previous_stack))();
-		
+
 		// in case top_symbol is action type (apply it on previous subject and get new one)
 		if constexpr (std::is_base_of_v<ctll::action, decltype(top_symbol)>) {
 			auto subject = Actions::apply(top_symbol, get_previous_term<Pos>(), previous_subject);
-			
+
 			// in case that semantic action is error => reject input
 			if constexpr (std::is_same_v<ctll::reject, decltype(subject)>) {
 				return typename parser<Grammar, _input, ActionSelector, IgnoreUnknownActions>::template results<Pos, Stack, Subject, decision::reject>();
@@ -826,7 +826,7 @@ template <typename Grammar, const auto & input, typename ActionSelector = empty_
 			return move<Pos>(rule, current_term, stack, previous_subject);
 		}
 	}
-	
+
 	// trampolines with folded expression
 	template <typename Subject, size_t... Pos> static constexpr auto trampoline_decide(Subject, std::index_sequence<Pos...>) noexcept {
 		// parse everything for first char and than for next and next ...
@@ -834,12 +834,12 @@ template <typename Grammar, const auto & input, typename ActionSelector = empty_
 		auto v = (decide<0, typename grammar::start_stack, Subject>({}, {}) + ... + index_placeholder<Pos+1>());
 		return v;
 	}
-	
+
 	template <typename Subject = empty_subject> static constexpr auto trampoline_decide(Subject subject = {}) noexcept {
 		// there will be no recursion, just sequence long as the input
 		return trampoline_decide(subject, std::make_index_sequence<input.size()>());
 	}
-	
+
 	template <typename Subject = empty_subject> using output = decltype(trampoline_decide<Subject>());
 	template <typename Subject = empty_subject> static inline constexpr bool correct_with = trampoline_decide<Subject>();
 
@@ -2290,16 +2290,16 @@ template <size_t Id, typename Name = void> struct captured_content {
 		}
 		
 		friend CTRE_FORCE_INLINE constexpr bool operator==(const storage & lhs, std::basic_string_view<char_type> rhs) noexcept {
-			return lhs.view() == rhs;
+			return bool(lhs) ? lhs.view() == rhs : false;
 		}
 		friend CTRE_FORCE_INLINE constexpr bool operator!=(const storage & lhs, std::basic_string_view<char_type> rhs) noexcept {
-			return lhs.view() != rhs;
+			return bool(lhs) ? lhs.view() != rhs : false;
 		}
 		friend CTRE_FORCE_INLINE constexpr bool operator==(std::basic_string_view<char_type> lhs, const storage & rhs) noexcept {
-			return lhs == rhs.view();
+			return bool(rhs) ? lhs == rhs.view() : false;
 		}
 		friend CTRE_FORCE_INLINE constexpr bool operator!=(std::basic_string_view<char_type> lhs, const storage & rhs) noexcept {
-			return lhs != rhs.view();
+			return bool(rhs) ? lhs != rhs.view() : false;
 		}
 	};
 };
@@ -2508,16 +2508,16 @@ public:
 		return *this;
 	}
 	friend CTRE_FORCE_INLINE constexpr bool operator==(const regex_results & lhs, std::basic_string_view<char_type> rhs) noexcept {
-		return lhs.view() == rhs;
+		return bool(lhs) ? lhs.view() == rhs : false;
 	}
 	friend CTRE_FORCE_INLINE constexpr bool operator!=(const regex_results & lhs, std::basic_string_view<char_type> rhs) noexcept {
-		return lhs.view() != rhs;
+		return bool(lhs) ? lhs.view() != rhs : true;
 	}
 	friend CTRE_FORCE_INLINE constexpr bool operator==(std::basic_string_view<char_type> lhs, const regex_results & rhs) noexcept {
-		return lhs == rhs.view();
+		return bool(rhs) ? lhs == rhs.view() : false;
 	}
 	friend CTRE_FORCE_INLINE constexpr bool operator!=(std::basic_string_view<char_type> lhs, const regex_results & rhs) noexcept {
-		return lhs != rhs.view();
+		return bool(rhs) ? lhs != rhs.view() : true;
 	}
 };
 


### PR DESCRIPTION
When compiled with GCC 9.3.1, it raises sign comparison warning as we're comparing char32_t (unsigned) to char (signed on some systems).  I added a static cast so the maximum char value (which is always positive) is casted to char32_t, eliminating the warning.

The other changes in the single-header file comes from running the make command.  I assume the single-header file is just not updated after recent changes.