### PR TITLE
Solving #109 with redundant inclusion guards

### DIFF
--- a/include/ctll.hpp
+++ b/include/ctll.hpp
@@ -1,6 +1,8 @@
 #ifndef CTRE_V2__CTLL__HPP
 #define CTRE_V2__CTLL__HPP
 
+#ifndef CTLL__PARSER__HPP
 #include "ctll/parser.hpp"
+#endif
 
 #endif

--- a/include/ctll/list.hpp
+++ b/include/ctll/list.hpp
@@ -1,7 +1,9 @@
 #ifndef CTLL__TYPE_STACK__HPP
 #define CTLL__TYPE_STACK__HPP
 
+#ifndef CTLL__UTILITIES__HPP
 #include "utilities.hpp"
+#endif
 
 namespace ctll {
 

--- a/include/ctll/parser.hpp
+++ b/include/ctll/parser.hpp
@@ -1,10 +1,21 @@
 #ifndef CTLL__PARSER__HPP
 #define CTLL__PARSER__HPP
 
+#ifndef CTLL__FIXED_STRING__GPP
 #include "fixed_string.hpp"
+#endif
+
+#ifndef CTLL__TYPE_STACK__HPP
 #include "list.hpp"
+#endif
+
+#ifndef CTLL__GRAMMARS__HPP
 #include "grammars.hpp"
+#endif
+
+#ifndef CTLL__ACTIONS__HPP
 #include "actions.hpp"
+#endif
 
 #include <limits>
 

--- a/include/ctre.hpp
+++ b/include/ctre.hpp
@@ -1,10 +1,24 @@
 #ifndef CTRE_V2__CTRE__HPP
 #define CTRE_V2__CTRE__HPP
 
+#ifndef CTRE_V2__CTRE__LITERALS__HPP
 #include "ctre/literals.hpp"
+#endif
+
+#ifndef CTRE_V2__CTRE__FUNCTIONS__HPP
 #include "ctre/functions.hpp"
+#endif
+
+#ifndef CTRE_V2__CTRE__ITERATOR__HPP
 #include "ctre/iterators.hpp"
+#endif
+
+#ifndef CTRE_V2__CTRE__RANGE__HPP
 #include "ctre/range.hpp"
+#endif
+
+#ifndef CTRE_V2__CTRE__OPERATORS__HPP
 #include "ctre/operators.hpp"
+#endif
 
 #endif

--- a/include/ctre/atoms_characters.hpp
+++ b/include/ctre/atoms_characters.hpp
@@ -1,7 +1,10 @@
 #ifndef CTRE__ATOMS_CHARACTERS__HPP
 #define CTRE__ATOMS_CHARACTERS__HPP
 
+#ifndef CTRE__UTILITY__HPP
 #include "utility.hpp"
+#endif
+
 #include <cstdint>
 
 namespace ctre {

--- a/include/ctre/evaluation.hpp
+++ b/include/ctre/evaluation.hpp
@@ -1,14 +1,40 @@
 #ifndef CTRE__EVALUATION__HPP
 #define CTRE__EVALUATION__HPP
 
+
+#endif
+
+#ifndef CTRE__ATOMS__HPP
 #include "atoms.hpp"
+
+#endif
+
+#ifndef CTRE__ATOMS_CHARACTERS__HPP
 #include "atoms_characters.hpp"
+
+#ifndef CTRE__ATOMS_UNICODE__HPP
 #include "atoms_unicode.hpp"
+#endif
+
+#ifndef CTRE__STARTS_WITH_ANCHOR__HPP
 #include "starts_with_anchor.hpp"
+#endif
+
+#ifndef CTRE__UTILITY__HPP
 #include "utility.hpp"
+#endif
+
+#ifndef CTRE__RETURN_TYPE__HPP
 #include "return_type.hpp"
+#endif
+
+#ifndef CTRE__FIND_CAPTURES__HPP
 #include "find_captures.hpp"
+#endif
+
+#ifndef CTRE__FIRST__HPP
 #include "first.hpp"
+#endif
 
 // remove me when MSVC fix the constexpr bug
 #ifdef _MSC_VER

--- a/include/ctre/evaluation.hpp
+++ b/include/ctre/evaluation.hpp
@@ -2,15 +2,13 @@
 #define CTRE__EVALUATION__HPP
 
 
-#endif
-
 #ifndef CTRE__ATOMS__HPP
 #include "atoms.hpp"
-
 #endif
 
 #ifndef CTRE__ATOMS_CHARACTERS__HPP
 #include "atoms_characters.hpp"
+#endif
 
 #ifndef CTRE__ATOMS_UNICODE__HPP
 #include "atoms_unicode.hpp"

--- a/include/ctre/find_captures.hpp
+++ b/include/ctre/find_captures.hpp
@@ -1,10 +1,21 @@
 #ifndef CTRE__FIND_CAPTURES__HPP
 #define CTRE__FIND_CAPTURES__HPP
 
+#ifndef CTRE__ATOMS_CHARACTERS__HPP
 #include "atoms_characters.hpp"
+#endif
+
+#ifndef CTRE__ATOMS_UNICODE__HPP
 #include "atoms_unicode.hpp"
+#endif
+
+#ifndef CTRE__UTILITY__HPP
 #include "utility.hpp"
+#endif
+
+#ifndef CTRE__RETURN_TYPE__HPP
 #include "return_type.hpp"
+#endif
 
 namespace ctre {
 

--- a/include/ctre/first.hpp
+++ b/include/ctre/first.hpp
@@ -1,9 +1,18 @@
 #ifndef CTRE__FIRST__HPP
 #define CTRE__FIRST__HPP
 
+#ifndef CTRE__ATOMS__HPP
 #include "atoms.hpp"
+#endif
+
+#ifndef CTRE__ATOMS_CHARACTERS__HPP
 #include "atoms_characters.hpp"
+#endif
+
+#ifndef CTRE__ATOMS_UNICODE__HPP
 #include "atoms_unicode.hpp"
+#endif
+
 
 namespace ctre {
 	

--- a/include/ctre/functions.hpp
+++ b/include/ctre/functions.hpp
@@ -1,7 +1,9 @@
 #ifndef CTRE_V2__CTRE__FUNCTIONS__HPP
 #define CTRE_V2__CTRE__FUNCTIONS__HPP
 
+#ifndef CTRE_V2__CTLL__HPP
 #include "../ctll.hpp"
+#endif
 
 #ifndef CTRE__PCRE_ACTIONS__HPP
 #include "pcre_actions.hpp"

--- a/include/ctre/functions.hpp
+++ b/include/ctre/functions.hpp
@@ -2,10 +2,22 @@
 #define CTRE_V2__CTRE__FUNCTIONS__HPP
 
 #include "../ctll.hpp"
+
+#ifndef CTRE__PCRE_ACTIONS__HPP
 #include "pcre_actions.hpp"
+#endif
+
+#ifndef CTRE__EVALUATION__HPP
 #include "evaluation.hpp"
+#endif
+
+#ifndef CTRE__WRAPPER__HPP
 #include "wrapper.hpp"
+#endif
+
+#ifndef CTRE__ID__HPP
 #include "id.hpp"
+#endif
 
 namespace ctre {
 

--- a/include/ctre/iterators.hpp
+++ b/include/ctre/iterators.hpp
@@ -2,11 +2,11 @@
 #define CTRE_V2__CTRE__ITERATOR__HPP
 
 #ifndef CTRE_V2__CTRE__LITERALS__HPP
-#include "ctre/literals.hpp"
+#include "literals.hpp"
 #endif
 
 #ifndef CTRE_V2__CTRE__FUNCTIONS__HPP
-#include "ctre/functions.hpp"
+#include "functions.hpp"
 #endif
 
 namespace ctre {

--- a/include/ctre/iterators.hpp
+++ b/include/ctre/iterators.hpp
@@ -1,8 +1,13 @@
 #ifndef CTRE_V2__CTRE__ITERATOR__HPP
 #define CTRE_V2__CTRE__ITERATOR__HPP
 
-#include "literals.hpp"
-#include "functions.hpp"
+#ifndef CTRE_V2__CTRE__LITERALS__HPP
+#include "ctre/literals.hpp"
+#endif
+
+#ifndef CTRE_V2__CTRE__FUNCTIONS__HPP
+#include "ctre/functions.hpp"
+#endif
 
 namespace ctre {
 

--- a/include/ctre/literals.hpp
+++ b/include/ctre/literals.hpp
@@ -1,11 +1,25 @@
 #ifndef CTRE_V2__CTRE__LITERALS__HPP
 #define CTRE_V2__CTRE__LITERALS__HPP
 
+#ifndef CTRE_V2__CTLL__HPP
 #include "../ctll.hpp"
+#endif
+
+#ifndef CTRE__PCRE_ACTIONS__HPP
 #include "pcre_actions.hpp"
+#endif
+
+#ifndef CTRE__EVALUATION__HPP
 #include "evaluation.hpp"
+#endif
+
+#ifndef CTRE__WRAPPER__HPP
 #include "wrapper.hpp"
+#endif
+
+#ifndef CTRE__ID__HPP
 #include "id.hpp"
+#endif
 
 #ifndef __EDG__
 

--- a/include/ctre/pcre_actions.hpp
+++ b/include/ctre/pcre_actions.hpp
@@ -1,11 +1,26 @@
 #ifndef CTRE__PCRE_ACTIONS__HPP
 #define CTRE__PCRE_ACTIONS__HPP
 
+#ifndef CTRE__PCRE__HPP
 #include "pcre.hpp"
+#endif
+
+#ifndef CTRE__ATOMS__HPP
 #include "atoms.hpp"
+#endif
+
+#ifndef CTRE__ATOMS_CHARACTERS__HPP
 #include "atoms_characters.hpp"
+#endif
+
+#ifndef CTRE__ATOMS_UNICODE__HPP
 #include "atoms_unicode.hpp"
+#endif
+
+#ifndef CTRE__ID__HPP
 #include "id.hpp"
+#endif
+
 #include <cstdint>
 #include <limits>
 

--- a/include/ctre/range.hpp
+++ b/include/ctre/range.hpp
@@ -1,7 +1,9 @@
 #ifndef CTRE_V2__CTRE__RANGE__HPP
 #define CTRE_V2__CTRE__RANGE__HPP
 
-#include "iterators.hpp"
+#ifndef CTRE_V2__CTRE__ITERATOR__HPP
+#include "ctre/iterators.hpp"
+#endif
 
 namespace ctre {
 

--- a/include/ctre/range.hpp
+++ b/include/ctre/range.hpp
@@ -2,7 +2,7 @@
 #define CTRE_V2__CTRE__RANGE__HPP
 
 #ifndef CTRE_V2__CTRE__ITERATOR__HPP
-#include "ctre/iterators.hpp"
+#include "iterators.hpp"
 #endif
 
 namespace ctre {

--- a/include/ctre/return_type.hpp
+++ b/include/ctre/return_type.hpp
@@ -1,7 +1,10 @@
 #ifndef CTRE__RETURN_TYPE__HPP
 #define CTRE__RETURN_TYPE__HPP
 
+#ifndef CTRE__ID__HPP
 #include "id.hpp"
+#endif
+
 #include <type_traits>
 #include <tuple>
 #include <string_view>

--- a/include/ctre/wrapper.hpp
+++ b/include/ctre/wrapper.hpp
@@ -1,8 +1,14 @@
 #ifndef CTRE__WRAPPER__HPP
 #define CTRE__WRAPPER__HPP
 
+#ifndef CTRE__EVALUATION__HPP
 #include "evaluation.hpp"
+#endif
+
+#ifndef CTRE__UTILITY__HPP
 #include "utility.hpp"
+#endif
+
 #include <string_view>
 #include <string>
 


### PR DESCRIPTION
### Using redundant include guards to minimize the compilation time

C Preprocessor inclusions could explode the compilation time (even with pragma once!)

The basic idea comes from an old, dusty C++ book called Large Scale C++ Software Design, page 83-88.

Expanding the `evaluate` method indicated in the issue #109, everytime the `?` in `0?1?2?3?4?5?6?7?8?9?` is parsed, a new template instantiation begins, reading all the files again in the `#include`s, and increasing exponentially the compilation time.

I didn't use any redundant include guards in the standard header files. They could be used into them, too, in order to reduce even more the compilation times.

Test case:
`0?1?2?3?4?5?6?7?8?9?`
Even worst compile time test case:
`a?b?c?d?e?f?g?h?i?j?l?m?n?o?p?q?r?s?t?u?v?w?x?y?z?`