### PR TITLE
Minor Readme fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 [![Build Status](https://travis-ci.org/hanickadot/compile-time-regular-expressions.svg?branch=master)](https://travis-ci.org/hanickadot/compile-time-regular-expressions)
 
-Fast compile-time regular expression with support for matching/searching/capturing in compile-time or runtime.
+Fast compile-time regular expressions with support for matching/searching/capturing during compile-time or runtime.
 
-You can use single header version from directory `single-header`. This header can be regenerated with `make single-header`.
+You can use the single header version from directory `single-header`. This header can be regenerated with `make single-header`.
 
 More info at [compile-time.re](https://compile-time.re/)
 
-## What this library can do?
+## What this library can do
 
 ```c++
 ctre::match<"REGEX">(subject); // C++20
@@ -35,14 +35,14 @@ The library is implementing most of the PCRE syntax with a few exceptions:
 * octal numbers
 * options / modes
 * subroutines
-* unicode grapheme cluster (`\X`) 
+* unicode grapheme cluster (`\X`)
 
-More documentation on [pcre.org](https://www.pcre.org/current/doc/html/pcre2syntax.html). 
+More documentation on [pcre.org](https://www.pcre.org/current/doc/html/pcre2syntax.html).
 
-### What can be subject (input)?
+### Possible subjects (inputs)
 
-* `std::string`-like object (`std::string_view` or your own string if it's providing `begin`/`end` functions with forward iterators)
-* pair of forward iterators
+* `std::string`-like objects (`std::string_view` or your own string if it's providing `begin`/`end` functions with forward iterators)
+* pairs of forward iterators
 
 ## Supported compilers
 
@@ -52,59 +52,61 @@ More documentation on [pcre.org](https://www.pcre.org/current/doc/html/pcre2synt
 * gcc 9.0+ (C++17 & C++20 cNTTP syntax)
 * MSVC 15.8.8+ (C++17 syntax only) (semi-supported, I don't have windows machine)
 
-#### Template UDL syntax
+### Template UDL syntax
 
-Compiler must support N3599 extension, as GNU extension in gcc (not in GCC 9.1+) and clang.
+The compiler must support extension N3599, for example as GNU extension in gcc (not in GCC 9.1+) and clang.
 
 ```c++
 constexpr auto match(std::string_view sv) noexcept {
-	using namespace ctre::literals;
-	return "h.*"_ctre.match(sv);
+    using namespace ctre::literals;
+    return "h.*"_ctre.match(sv);
 }
 ```
 
-If you need N3599 extension in GCC 9.1+ you can't use -pedantic mode and define macro `CTRE_ENABLE_LITERALS`.
+If you need extension N3599 in GCC 9.1+, you can't use -pedantic. Also, you need to define macro `CTRE_ENABLE_LITERALS`.
 
-#### C++17 syntax
+### C++17 syntax
 
-You can provide pattern as a `constexpr ctll::fixed_string` variable.
+You can provide a pattern as a `constexpr ctll::fixed_string` variable.
 
 ```c++
 static constexpr auto pattern = ctll::fixed_string{ "h.*" };
 
 constexpr auto match(std::string_view sv) noexcept {
-	return ctre::match<pattern>(sv);
+    return ctre::match<pattern>(sv);
 }
 ```
 
 (this is tested in MSVC 15.8.8)
 
-#### C++20 syntax
+### C++20 syntax
 
-Currently only compiler which supports cNTTP syntax `ctre::match<PATTERN>(subject)` is GCC 9+.
+Currently, the only compiler which supports cNTTP syntax `ctre::match<PATTERN>(subject)` is GCC 9+.
 
 ```c++
 constexpr auto match(std::string_view sv) noexcept {
-	return ctre::match<"h.*">(sv);
+    return ctre::match<"h.*">(sv);
 }
 ```
 
 ## Examples
 
-#### Extracting number from input
+### Extracting number from input
+
 ```c++
 std::optional<std::string_view> extract_number(std::string_view s) noexcept {
-	if (auto m = ctre::match<"[a-z]+([0-9]+)">(s)) {
+    if (auto m = ctre::match<"[a-z]+([0-9]+)">(s)) {
         return m.get<1>().to_view();
     } else {
         return std::nullopt;
     }
 }
 ```
+
 [link to compiler explorer](https://gcc.godbolt.org/z/5U67_e)
 
+### Extracting values from date
 
-#### Extracting values from date
 ```c++
 struct date { std::string_view year; std::string_view month; std::string_view day; };
 
@@ -122,9 +124,11 @@ std::optional<date> extract_date(std::string_view s) noexcept {
 //static_assert((*extract_date("2018/08/27"sv)).month == "08"sv);
 //static_assert((*extract_date("2018/08/27"sv)).day == "27"sv);
 ```
+
 [link to compiler explorer](https://gcc.godbolt.org/z/x64CVp)
 
-##### Using captures
+### Using captures
+
 ```c++
 auto result = ctre::match<"(?<year>\\d{4})/(?<month>\\d{1,2})/(?<day>\\d{1,2})">(s);
 return date{result.get<"year">(), result.get<"month">, result.get<"day">};
@@ -140,7 +144,8 @@ return date{result.get<year>(), result.get<month>, result.get<day>};
 return date{result.get<1>(), result.get<2>, result.get<3>};
 ```
 
-#### Lexer
+### Lexer
+
 ```c++
 enum class type {
     unknown, identifier, number
@@ -162,16 +167,17 @@ std::optional<lex_item> lexer(std::string_view v) noexcept {
     return std::nullopt;
 }
 ```
+
 [link to compiler explorer](https://gcc.godbolt.org/z/PKTiCC)
 
-#### Range over input
+### Range over input
 
-This support is preliminary and probably the API will be changed.
+This support is preliminary, probably the API will be changed.
 
 ```c++
 auto input = "123,456,768"sv;
 
 for (auto match: ctre::range<"([0-9]+),?">(input)) {
-	std::cout << std::string_view{match.get<0>()} << "\n";
+    std::cout << std::string_view{match.get<0>()} << "\n";
 }
 ```


### PR DESCRIPTION
This is a very cool library!

I saw potential for a couple of grammar improvements in the README, and while editing it, my editor's [markdownlint](https://github.com/DavidAnson/markdownlint) pointed me to a couple of further issues (trailing whitespaces, tabs instead of spaces etc.) which I also resolved.

We can of course discuss the changes that I made. I'm especially skeptical of the following things that markdownlint required:

- No punctuation in headlines (which is why I had to remove the questions)
- Heading levels may not increase more than 1 from one heading to the next
