### PR TITLE
[WIP] Prefix needle optimization

### DIFF
--- a/include/ctre/evaluation.hpp
+++ b/include/ctre/evaluation.hpp
@@ -116,10 +116,17 @@ template <typename CharT, typename Iterator, typename EndIterator> constexpr CTR
 }
 
 template <auto... String, size_t... Idx, typename Iterator, typename EndIterator> constexpr CTRE_FORCE_INLINE string_match_result<Iterator> evaluate_match_string(Iterator current, [[maybe_unused]] const EndIterator end, std::index_sequence<Idx...>) noexcept {
-
-	bool same = (compare_character(String, current, end) && ... && true);
-
-	return {current, same};
+	if constexpr (!std::is_same_v<Iterator, utf8_iterator> && is_random_accessible(typename std::iterator_traits<Iterator>::iterator_category{})) {
+		bool same = (::std::distance(current, end) >= sizeof...(String)) && ((String == *(current + Idx)) & ...);
+		if (same) {
+			return {current+=sizeof...(String), same};
+		} else {
+			return {current, same};
+		}
+	} else {
+		bool same = (compare_character(String, current, end) && ... && true);
+		return { current, same };
+	}
 }
 
 template <typename R, typename Iterator, typename EndIterator, auto... String, typename... Tail> 
@@ -522,6 +529,163 @@ constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, c
 	}
 }
 
+template <typename T>
+constexpr bool is_string(T) {
+	return false;
+}
+template <auto... String>
+constexpr bool is_string(string<String...>) {
+	return true;
+}
+
+template <typename T>
+constexpr bool is_string_like(T) {
+	return false;
+}
+template <auto... String>
+constexpr bool is_string_like(string<String...>) {
+	return true;
+}
+template <typename CharacterLike, typename = std::enable_if_t<MatchesCharacter<CharacterLike>::template value<decltype(*std::declval<std::string_view::iterator>())>>>
+constexpr bool is_string_like(CharacterLike) {
+	return true;
+}
+
+template <typename... Content>
+constexpr auto extract_leading_string(ctll::list<Content...>) -> ctll::list<Content...> {
+	return {};
+};
+template <typename... Content>
+constexpr auto extract_leading_string(sequence<Content...>) -> sequence<Content...> {
+	return {};
+};
+
+//concatenation
+template <auto C, auto... String, typename... Content>
+constexpr auto extract_leading_string(ctll::list<string<String...>, character<C>, Content...>) {
+	return extract_leading_string(ctll::list<string<String..., C>, Content...>());
+}
+
+template <auto... StringA, auto... StringB, typename... Content>
+constexpr auto extract_leading_string(ctll::list<string<StringA...>, string<StringB...>, Content...>) {
+	return extract_leading_string(ctll::list<string<StringA..., StringB>, Content...>());
+}
+//move things up out of sequences
+template <typename... Content, typename... Tail>
+constexpr auto extract_leading_string(ctll::list<sequence<Content...>, Tail...>) {
+	return extract_leading_string(ctll::list<Content..., Tail...>());
+}
+
+template <typename T, typename... Content, typename... Tail>
+constexpr auto extract_leading_string(ctll::list<T, sequence<Content...>, Tail...>) {
+	return extract_leading_string(ctll::list<T, Content..., Tail...>());
+}
+
+template <typename... Content>
+constexpr auto make_into_sequence(ctll::list<Content...>) -> sequence<Content...> {
+	return{};
+}
+template <typename... Content>
+constexpr auto make_into_sequence(sequence<Content...>) -> sequence<Content...> {
+	return{};
+}
+
+//boyer moore utils
+template<typename Ty>
+constexpr bool is_prefix(Ty* word, size_t wordlen, ptrdiff_t pos) {
+	ptrdiff_t suffixlen = wordlen - pos;
+	for (int i = 0; i < suffixlen; i++) {
+		if (word[i] != word[pos + i]) {
+			return false;
+		}
+	}
+	return true;
+}
+
+template<typename Ty>
+constexpr size_t suffix_length(Ty* word, size_t wordlen, ptrdiff_t pos) {
+	size_t i = 0;
+	// increment suffix length i to the first mismatch or beginning of the word
+	for (; (word[pos - i] == word[wordlen - 1 - i]) && (i < pos); i++);
+	return i;
+}
+//MSVC workaround, array operator[] blows up in face if constexpr, use pointers instead
+template<typename Ty, auto... String>
+constexpr auto make_delta_2(string<String...>) {
+	std::array<Ty, sizeof...(String)> chars{ String... };
+	std::array<ptrdiff_t, sizeof...(String)> table;
+	constexpr size_t patlen = sizeof...(String);
+	size_t p = 0;
+	size_t last_prefix_index = patlen - 1;
+
+	for (p = patlen - 1; p < patlen; p--) {
+		if (is_prefix(chars.data(), patlen, p + 1)) {
+			last_prefix_index = p + 1;
+		}
+		table.data()[p] = last_prefix_index + (patlen - 1 - p);
+	}
+
+	for (p = 0; p < patlen - 1; p++) {
+		size_t slen = suffix_length(chars.data(), patlen, p);
+		if (chars.data()[p - slen] != chars.data()[patlen - 1 - slen]) {
+			table.data()[patlen - 1 - slen] = patlen - 1 - p + slen;
+		}
+	}
+
+	return table;
+}
+
+template <typename Iterator> struct string_search_result {
+	Iterator position;
+	Iterator end_position;
+	bool match;
+};
+
+template <typename Iterator, typename EndIterator, auto... String>
+constexpr CTRE_FORCE_INLINE string_search_result<Iterator> search_for_string(Iterator current, const EndIterator end, string<String...>) {
+	if constexpr (sizeof...(String) > 2 && !std::is_same_v<Iterator, utf8_iterator> && is_random_accessible(typename std::iterator_traits<Iterator>::iterator_category{})) {
+		constexpr std::array<typename ::std::iterator_traits<Iterator>::value_type, sizeof...(String)> chars{ String... };
+		constexpr std::array<ptrdiff_t, sizeof...(String)> delta_2 = make_delta_2<typename ::std::iterator_traits<Iterator>::value_type>(string<String...>());
+
+		size_t str_size = std::distance(current, end);
+		if (str_size < sizeof...(String)) { //quick exit no way to match
+			return { current + str_size, current + str_size, false };
+		}
+
+		size_t i = sizeof...(String) - 1; //index over to the starting location
+		for (; i < str_size;) {
+			size_t j = sizeof...(String) - 1;
+			size_t m = i + 1;
+			for (; *(current + i) == *(chars.data() + j); --i, --j) { //match string in reverse
+				if (j == 0) {
+					return { current + i, current + m, true };
+				}
+			}
+			size_t shift = enumeration<String...>::match_char(*(current + i)) ? static_cast<size_t>(*(delta_2.data() + j)) : sizeof...(String);
+			i += shift;
+		}
+
+		return { current + str_size, current + str_size, false };
+	} else if (sizeof...(String)) {
+		//fallback to plain string matching
+		constexpr std::array<typename ::std::iterator_traits<Iterator>::value_type, sizeof...(String)> chars{ String... };
+		constexpr typename ::std::iterator_traits<Iterator>::value_type first_char = chars.data()[0];
+		while (current != end) {
+			while (current != end && *current != first_char) {
+				current++;
+			}
+			auto result = evaluate_match_string<String...>(current, end, std::make_index_sequence<sizeof...(String)>());
+			if (result.match) {
+				return { current, result.position, result.match };
+			} else {
+				++current;
+			}
+		}
+		return { current, current, false };
+	} else {
+		return { current, current, true };
+	}
+}
 
 }
 

--- a/include/ctre/wrapper.hpp
+++ b/include/ctre/wrapper.hpp
@@ -71,7 +71,8 @@ struct search_method {
 			return_type<result_iterator, RE> result{};
 			for (; end != it2.position;) {
 				result.set_start_mark(it2.position);
-				if (result = evaluate(orig_begin, it2.end_position, end, Modifier{}, result, ctll::list<start_mark, decltype(make_into_sequence(front_re{}.list)), end_mark, accept>())) {
+				result = evaluate(orig_begin, it2.end_position, end, Modifier{}, result, ctll::list<start_mark, decltype(make_into_sequence(front_re{}.list)), end_mark, accept>());
+				if (result) {
 					return result;
 				}
 				result.unmatch();
@@ -80,7 +81,7 @@ struct search_method {
 			}
 			result.set_start_mark(it2.position);
 			return result = evaluate(orig_begin, it2.end_position, end, Modifier{}, result, ctll::list<start_mark, decltype(make_into_sequence(front_re{}.list)), end_mark, accept>());
-		} else if (is_string(front_re{}.front)) {
+		} else if constexpr (is_string(front_re{}.front)) {
 			auto it2 = search_for_string(it, end, front_re{}.front);
 			return_type<result_iterator, RE> result{};
 			result.set_start_mark(it2.position);

--- a/include/ctre/wrapper.hpp
+++ b/include/ctre/wrapper.hpp
@@ -67,23 +67,27 @@ struct search_method {
 	
 		auto it = begin;
 		if constexpr (is_string(front_re{}.front) && size(front_re{}.list)) {
-			it = search_for_string(it, end, front_re{}.front).position;
-			for (; end != it;) {
-				if (auto out = evaluate(orig_begin, it, end, Modifier{}, return_type<result_iterator, RE>{}, ctll::list<start_mark, sequence<decltype(front_re{}.front), decltype(make_into_sequence(front_re{}.list))>, end_mark, accept>())) {
-					return out;
+			auto it2 = search_for_string(it, end, front_re{}.front);
+			return_type<result_iterator, RE> result{};
+			for (; end != it2.position;) {
+				result.set_start_mark(it2.position);
+				if (result = evaluate(orig_begin, it2.end_position, end, Modifier{}, result, ctll::list<start_mark, decltype(make_into_sequence(front_re{}.list)), end_mark, accept>())) {
+					return result;
 				}
-				it = search_for_string(++it, end, front_re{}.front).position;
+				result.unmatch();
+				std::advance(it2.position, 1);
+				it2 = search_for_string(it2.position, end, front_re{}.front);
 			}
-			return evaluate(orig_begin, it, end, Modifier{}, return_type<result_iterator, RE>{}, ctll::list<start_mark, sequence<decltype(front_re{}.front), decltype(make_into_sequence(front_re{}.list))>, end_mark, accept>());
+			result.set_start_mark(it2.position);
+			return result = evaluate(orig_begin, it2.end_position, end, Modifier{}, result, ctll::list<start_mark, decltype(make_into_sequence(front_re{}.list)), end_mark, accept>());
 		} else if (is_string(front_re{}.front)) {
-			it = search_for_string(it, end, front_re{}.front).position;
-			for (; end != it;) {
-				if (auto out = evaluate(orig_begin, it, end, Modifier{}, return_type<result_iterator, RE>{}, ctll::list<start_mark, decltype(front_re{}.front), end_mark, accept>())) {
-					return out;
-				}
-				it = search_for_string(++it, end, front_re{}.front).position;
-			}
-			return evaluate(orig_begin, it, end, Modifier{}, return_type<result_iterator, RE>{}, ctll::list<start_mark, decltype(front_re{}.front), end_mark, accept>());
+			auto it2 = search_for_string(it, end, front_re{}.front);
+			return_type<result_iterator, RE> result{};
+			result.set_start_mark(it2.position);
+			result.set_end_mark(it2.end_position);
+			if (it2.match)
+				result.matched();
+			return result;
 		} else {
 			for (; end != it && !fixed; ++it) {
 				if (auto out = evaluate(orig_begin, it, end, Modifier{}, return_type<result_iterator, RE>{}, ctll::list<start_mark, RE, end_mark, accept>())) {


### PR DESCRIPTION
Adds a bit of machinery to try to extract a leading string<> if we're about to search.
Things to improve on
- better string extraction, currently very simple only looks for string<> and char<> (may be buried in sequence<>)
- generalization to string like things
- utf8 strings, boyer moore is bidirectional, utf8 is best handled forwards only

combines both #143 #146 
From testing there's anywhere upwards of a 50% performance improvement (when dealing with non-unicode things).