### PR TITLE
Select optimization: Avoid backtracking on mutually exclusive branches

### DIFF
--- a/include/ctre/atoms_characters.hpp
+++ b/include/ctre/atoms_characters.hpp
@@ -24,13 +24,13 @@ template <auto V> struct character {
 };
 
 template <typename... Content> struct negative_set {
-	template <typename CharT> CTRE_FORCE_INLINE static constexpr bool match_char(CharT value) noexcept {
+	template <typename CharT> CTRE_FORCE_INLINE static constexpr bool match_char([[maybe_unused]] CharT value) noexcept {
 		return !(Content::match_char(value) || ... || false);
 	}
 };
 
 template <typename... Content> struct set {
-	template <typename CharT> CTRE_FORCE_INLINE static constexpr bool match_char(CharT value) noexcept {
+	template <typename CharT> CTRE_FORCE_INLINE static constexpr bool match_char([[maybe_unused]] CharT value) noexcept {
 		return (Content::match_char(value) || ... || false);
 	}
 };
@@ -38,7 +38,7 @@ template <typename... Content> struct set {
 template <auto... Cs> struct enumeration : set<character<Cs>...> { };
 
 template <typename... Content> struct negate {
-	template <typename CharT> CTRE_FORCE_INLINE static constexpr bool match_char(CharT value) noexcept {
+	template <typename CharT> CTRE_FORCE_INLINE static constexpr bool match_char([[maybe_unused]] CharT value) noexcept {
 		return !(Content::match_char(value) || ... || false);
 	}
 };

--- a/include/ctre/first.hpp
+++ b/include/ctre/first.hpp
@@ -368,6 +368,21 @@ template <typename CB> constexpr void negative_helper(ctre::negative_set<>, CB &
 	}
 }
 
+template <typename... Content>
+constexpr auto transform_into_set(ctll::list<Content...>) {
+	return ctre::set<decltype(transform_into_set(Content{}))...>{};
+}
+
+template <typename T>
+constexpr auto transform_into_set(T) {
+	return T{};
+}
+
+template<>
+constexpr auto transform_into_set(can_be_anything) {
+	return ctre::char_range<std::numeric_limits<int64_t>::min(), std::numeric_limits<int64_t>::max()>{};
+}
+
 // simple fixed set
 // TODO: this needs some optimizations
 template <size_t Capacity> class point_set {
@@ -469,6 +484,9 @@ public:
 	constexpr bool check(can_be_anything) {
 		return used > 0;
 	}
+	constexpr bool check(empty) {
+		return used == 0;
+	}
 	template <typename... Content> constexpr bool check(ctre::negative_set<Content...> nset) {
 		bool collision = false;
 		negative_helper(nset, [&](int64_t low, int64_t high){
@@ -496,6 +514,9 @@ public:
 	}
 	constexpr void populate(can_be_anything) {
 		insert(std::numeric_limits<int64_t>::min(), std::numeric_limits<int64_t>::max());
+	}
+	constexpr void populate(empty) {
+		//do nothing
 	}
 	template <typename... Content> constexpr void populate(ctre::negative_set<Content...> nset) {
 		negative_helper(nset, [&](int64_t low, int64_t high){


### PR DESCRIPTION
When we match against characters that belong to no other select branch we can avoid backtracking by a significant amount.
Note: HeadOptions could be a fairly large sequence*. I updated to use calculate_first() to evaluate the initial condition and backtrack by at worst one character*

See comparison: https://compiler-explorer.com/z/8ea8Pr
*Updated: https://compiler-explorer.com/z/vPEq1T