### PR TITLE
Optimization: Check for implicit anchor

### DIFF
--- a/include/ctre/evaluation.hpp
+++ b/include/ctre/evaluation.hpp
@@ -5,6 +5,7 @@
 #include "atoms.hpp"
 #include "atoms_unicode.hpp"
 #include "starts_with_anchor.hpp"
+#include "has_implicit_anchor.hpp"
 #include "utility.hpp"
 #include "return_type.hpp"
 #include "find_captures.hpp"

--- a/include/ctre/has_implicit_anchor.hpp
+++ b/include/ctre/has_implicit_anchor.hpp
@@ -1,0 +1,68 @@
+#ifndef CTRE__HAS_IMPLICIT_ANCHOR__HPP
+#define CTRE__HAS_IMPLICIT_ANCHOR__HPP
+
+#include "atoms.hpp"
+#include "atoms_unicode.hpp"
+
+namespace ctre {
+
+	template<typename... Content>
+	constexpr bool has_implicit_anchor(ctll::list<repeat<0, 0, any>, Content...>) noexcept {
+		return true;
+	}
+	template<typename... Content>
+	constexpr bool has_implicit_anchor(ctll::list<repeat<1, 0, any>, Content...>) noexcept {
+		return true;
+	}
+
+	template<typename... Content>
+	constexpr bool has_implicit_anchor(ctll::list<possessive_repeat<0, 0, any>, Content...>) noexcept {
+		return true;
+	}
+
+	template<typename... Content>
+	constexpr bool has_implicit_anchor(ctll::list<possessive_repeat<1, 0, any>, Content...>) noexcept {
+		return true;
+	}
+
+	template<typename... Content>
+	constexpr bool has_implicit_anchor(ctll::list<lazy_repeat<0, 0, any>, Content...>) noexcept {
+		return true;
+	}
+
+	template<typename... Content>
+	constexpr bool has_implicit_anchor(ctll::list<lazy_repeat<1, 0, any>, Content...>) noexcept {
+		return true;
+	}
+
+	template<typename... Content, typename... Tail>
+	constexpr bool has_implicit_anchor(ctll::list<sequence<Content...>, Tail...>) noexcept {
+		return has_implicit_anchor(ctll::list<Content..., Tail...>{});
+	}
+
+	//TODO: we may check captures as implicit anchors*, but they must not be backreferenced because for example "(.+)X\1" will not work properly with "1234X2345"
+	/*
+	template<size_t Id, typename... Content, typename... Tail>
+	constexpr bool has_implicit_anchor(ctll::list<capture<Id, Content...>, Tail...>) noexcept {
+		//Id must not be backreferenced
+		return !id_backreference(Id) && has_implicit_anchor(ctll::list<Content..., Tail...>{});
+	}
+
+	template<size_t Id, typename Name, typename... Content, typename... Tail>
+	constexpr bool has_implicit_anchor(ctll::list<capture_with_name<Id, Name, Content...>, Tail...>) noexcept {
+		//Id must not be backreferenced
+		return !id_backreference(Id) && has_implicit_anchor(ctll::list<Content..., Tail...>{});
+	}
+	*/
+
+	template<typename... Opts, typename... Tail>
+	constexpr bool has_implicit_anchor(ctll::list<select<Opts...>, Tail...>) noexcept {
+		return (has_implicit_anchor(ctll::list<Opts, Tail...>{}) && ...);
+	}
+
+	constexpr bool has_implicit_anchor(...) noexcept {
+		return false;
+	}
+}
+
+#endif

--- a/include/ctre/wrapper.hpp
+++ b/include/ctre/wrapper.hpp
@@ -62,7 +62,7 @@ struct search_method {
 	template <typename Modifier = singleline, typename ResultIterator = void, typename RE, typename IteratorBegin, typename IteratorEnd> constexpr CTRE_FORCE_INLINE static auto exec(IteratorBegin orig_begin, IteratorBegin begin, IteratorEnd end, RE) noexcept {
 		using result_iterator = std::conditional_t<std::is_same_v<ResultIterator, void>, IteratorBegin, ResultIterator>;
 		
-		constexpr bool fixed = starts_with_anchor(Modifier{}, ctll::list<RE>{});
+		constexpr bool fixed = starts_with_anchor(Modifier{}, ctll::list<RE>{}) || has_implicit_anchor(ctll::list<RE>{});
 	
 		auto it = begin;
 	

--- a/single-header/ctre-unicode.hpp
+++ b/single-header/ctre-unicode.hpp
@@ -2720,6 +2720,72 @@ constexpr bool starts_with_anchor(const flags & f, ctll::list<capture_with_name<
 
 #endif
 
+#ifndef CTRE__HAS_IMPLICIT_ANCHOR__HPP
+#define CTRE__HAS_IMPLICIT_ANCHOR__HPP
+
+namespace ctre {
+
+	template<typename... Content>
+	constexpr bool has_implicit_anchor(ctll::list<repeat<0, 0, any>, Content...>) noexcept {
+		return true;
+	}
+	template<typename... Content>
+	constexpr bool has_implicit_anchor(ctll::list<repeat<1, 0, any>, Content...>) noexcept {
+		return true;
+	}
+
+	template<typename... Content>
+	constexpr bool has_implicit_anchor(ctll::list<possessive_repeat<0, 0, any>, Content...>) noexcept {
+		return true;
+	}
+
+	template<typename... Content>
+	constexpr bool has_implicit_anchor(ctll::list<possessive_repeat<1, 0, any>, Content...>) noexcept {
+		return true;
+	}
+
+	template<typename... Content>
+	constexpr bool has_implicit_anchor(ctll::list<lazy_repeat<0, 0, any>, Content...>) noexcept {
+		return true;
+	}
+
+	template<typename... Content>
+	constexpr bool has_implicit_anchor(ctll::list<lazy_repeat<1, 0, any>, Content...>) noexcept {
+		return true;
+	}
+
+	template<typename... Content, typename... Tail>
+	constexpr bool has_implicit_anchor(ctll::list<sequence<Content...>, Tail...>) noexcept {
+		return has_implicit_anchor(ctll::list<Content..., Tail...>{});
+	}
+
+	//TODO: we may check captures as implicit anchors*, but they must not be backreferenced because for example "(.+)X\1" will not work properly with "1234X2345"
+	/*
+	template<size_t Id, typename... Content, typename... Tail>
+	constexpr bool has_implicit_anchor(ctll::list<capture<Id, Content...>, Tail...>) noexcept {
+		//Id must not be backreferenced
+		return !id_backreference(Id) && has_implicit_anchor(ctll::list<Content..., Tail...>{});
+	}
+
+	template<size_t Id, typename Name, typename... Content, typename... Tail>
+	constexpr bool has_implicit_anchor(ctll::list<capture_with_name<Id, Name, Content...>, Tail...>) noexcept {
+		//Id must not be backreferenced
+		return !id_backreference(Id) && has_implicit_anchor(ctll::list<Content..., Tail...>{});
+	}
+	*/
+
+	template<typename... Opts, typename... Tail>
+	constexpr bool has_implicit_anchor(ctll::list<select<Opts...>, Tail...>) noexcept {
+		return (has_implicit_anchor(ctll::list<Opts, Tail...>{}) && ...);
+	}
+
+	constexpr bool has_implicit_anchor(...) noexcept {
+		return false;
+	}
+}
+
+#endif
+
 #ifndef CTRE__RETURN_TYPE__HPP
 #define CTRE__RETURN_TYPE__HPP
 
@@ -4878,7 +4944,7 @@ struct search_method {
 	template <typename Modifier = singleline, typename ResultIterator = void, typename RE, typename IteratorBegin, typename IteratorEnd> constexpr CTRE_FORCE_INLINE static auto exec(IteratorBegin orig_begin, IteratorBegin begin, IteratorEnd end, RE) noexcept {
 		using result_iterator = std::conditional_t<std::is_same_v<ResultIterator, void>, IteratorBegin, ResultIterator>;
 		
-		constexpr bool fixed = starts_with_anchor(Modifier{}, ctll::list<RE>{});
+		constexpr bool fixed = starts_with_anchor(Modifier{}, ctll::list<RE>{}) || has_implicit_anchor(ctll::list<RE>{});
 	
 		auto it = begin;
 	

--- a/single-header/ctre.hpp
+++ b/single-header/ctre.hpp
@@ -2717,6 +2717,72 @@ constexpr bool starts_with_anchor(const flags & f, ctll::list<capture_with_name<
 
 #endif
 
+#ifndef CTRE__HAS_IMPLICIT_ANCHOR__HPP
+#define CTRE__HAS_IMPLICIT_ANCHOR__HPP
+
+namespace ctre {
+
+	template<typename... Content>
+	constexpr bool has_implicit_anchor(ctll::list<repeat<0, 0, any>, Content...>) noexcept {
+		return true;
+	}
+	template<typename... Content>
+	constexpr bool has_implicit_anchor(ctll::list<repeat<1, 0, any>, Content...>) noexcept {
+		return true;
+	}
+
+	template<typename... Content>
+	constexpr bool has_implicit_anchor(ctll::list<possessive_repeat<0, 0, any>, Content...>) noexcept {
+		return true;
+	}
+
+	template<typename... Content>
+	constexpr bool has_implicit_anchor(ctll::list<possessive_repeat<1, 0, any>, Content...>) noexcept {
+		return true;
+	}
+
+	template<typename... Content>
+	constexpr bool has_implicit_anchor(ctll::list<lazy_repeat<0, 0, any>, Content...>) noexcept {
+		return true;
+	}
+
+	template<typename... Content>
+	constexpr bool has_implicit_anchor(ctll::list<lazy_repeat<1, 0, any>, Content...>) noexcept {
+		return true;
+	}
+
+	template<typename... Content, typename... Tail>
+	constexpr bool has_implicit_anchor(ctll::list<sequence<Content...>, Tail...>) noexcept {
+		return has_implicit_anchor(ctll::list<Content..., Tail...>{});
+	}
+
+	//TODO: we may check captures as implicit anchors*, but they must not be backreferenced because for example "(.+)X\1" will not work properly with "1234X2345"
+	/*
+	template<size_t Id, typename... Content, typename... Tail>
+	constexpr bool has_implicit_anchor(ctll::list<capture<Id, Content...>, Tail...>) noexcept {
+		//Id must not be backreferenced
+		return !id_backreference(Id) && has_implicit_anchor(ctll::list<Content..., Tail...>{});
+	}
+
+	template<size_t Id, typename Name, typename... Content, typename... Tail>
+	constexpr bool has_implicit_anchor(ctll::list<capture_with_name<Id, Name, Content...>, Tail...>) noexcept {
+		//Id must not be backreferenced
+		return !id_backreference(Id) && has_implicit_anchor(ctll::list<Content..., Tail...>{});
+	}
+	*/
+
+	template<typename... Opts, typename... Tail>
+	constexpr bool has_implicit_anchor(ctll::list<select<Opts...>, Tail...>) noexcept {
+		return (has_implicit_anchor(ctll::list<Opts, Tail...>{}) && ...);
+	}
+
+	constexpr bool has_implicit_anchor(...) noexcept {
+		return false;
+	}
+}
+
+#endif
+
 #ifndef CTRE__RETURN_TYPE__HPP
 #define CTRE__RETURN_TYPE__HPP
 
@@ -4875,7 +4941,7 @@ struct search_method {
 	template <typename Modifier = singleline, typename ResultIterator = void, typename RE, typename IteratorBegin, typename IteratorEnd> constexpr CTRE_FORCE_INLINE static auto exec(IteratorBegin orig_begin, IteratorBegin begin, IteratorEnd end, RE) noexcept {
 		using result_iterator = std::conditional_t<std::is_same_v<ResultIterator, void>, IteratorBegin, ResultIterator>;
 		
-		constexpr bool fixed = starts_with_anchor(Modifier{}, ctll::list<RE>{});
+		constexpr bool fixed = starts_with_anchor(Modifier{}, ctll::list<RE>{}) || has_implicit_anchor(ctll::list<RE>{});
 	
 		auto it = begin;
 	


### PR DESCRIPTION
Slight improvement on #95

From O'Reilly's book:
> An engine with this optimization realizes that if a regex begins with .* or .+ and has no global alternation an implicit ^ can be prepended to the regex.

Intuition is that `.*` and `.+` collide / consume all the initial characters that don't really match the pattern ergo .* and .+ will consume the entire input string in one go...bumping the initial start position is much like remaining in the .* or .+