### PR TITLE
Fold expression version of select<>

### DIFF
--- a/include/ctre/evaluation.hpp
+++ b/include/ctre/evaluation.hpp
@@ -136,11 +136,9 @@ constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, c
 // matching select in patterns
 template <typename R, typename Iterator, typename EndIterator, typename HeadOptions, typename... TailOptions, typename... Tail> 
 constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, const flags & f, R captures, ctll::list<select<HeadOptions, TailOptions...>, Tail...>) noexcept {
-	if (auto r = evaluate(begin, current, end, f, captures, ctll::list<HeadOptions, Tail...>())) {
-		return r;
-	} else {
-		return evaluate(begin, current, end, f, captures, ctll::list<select<TailOptions...>, Tail...>());
-	}
+	R inner_result = evaluate(begin, current, end, f, captures, ctll::list<HeadOptions, Tail...>()); //first branch
+	((!inner_result && (inner_result = evaluate(begin, current, end, f, captures, ctll::list<TailOptions, Tail...>()))), ...); //all others
+	return inner_result;
 }
 
 template <typename R, typename Iterator, typename EndIterator, typename... Tail> 


### PR DESCRIPTION
Expresses select<> in a fold expression form, might improve compile times? gcc generates lower numbered labels which appear to refer to the same code which may indicate it's doing less work to eliminate branches.

https://compiler-explorer.com/z/41Kd76