### PR TITLE
Enable CTRE_FORCE_INLINE when clang or gcc is integrated in MSVC

### DIFF
--- a/include/ctll/utilities.hpp
+++ b/include/ctll/utilities.hpp
@@ -3,7 +3,9 @@
 
 #include <type_traits>
 
-#ifdef _MSC_VER
+#if defined(__clang__) || defined(__GNUC__)
+#define CTLL_FORCE_INLINE __attribute__((always_inline))
+#elif defined(_MSC_VER)
 #define CTLL_FORCE_INLINE __forceinline
 #else
 #define CTLL_FORCE_INLINE __attribute__((always_inline))

--- a/include/ctre/evaluation.hpp
+++ b/include/ctre/evaluation.hpp
@@ -12,7 +12,7 @@
 #include <iterator>
 
 // remove me when MSVC fix the constexpr bug
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__) && !defined(__GNUC__)
 #ifndef CTRE_MSVC_GREEDY_WORKAROUND
 #define CTRE_MSVC_GREEDY_WORKAROUND
 #endif

--- a/include/ctre/utility.hpp
+++ b/include/ctre/utility.hpp
@@ -18,7 +18,10 @@
 #define CTRE_UNLIKELY
 #endif
 
-#ifdef _MSC_VER
+#if defined(__clang__) || defined(__GNUC__)
+#define CTRE_FORCE_INLINE inline __attribute__((always_inline))
+#define CTRE_FLATTEN __attribute__((flatten))
+#elif defined(_MSC_VER)
 #define CTRE_FORCE_INLINE __forceinline
 #define CTRE_FLATTEN
 #else


### PR DESCRIPTION
When other compilers are integrated into the MSVC their compiler macros are defined in addition to _MSC_VER. Which confusingly means _MSC_VER only means the MSVC compiler if and only if no other compiler is detected.