### PR TITLE
Avoid -Wundef warnings from gcc

### DIFF
--- a/include/ctll/fixed_string.hpp
+++ b/include/ctll/fixed_string.hpp
@@ -42,7 +42,7 @@ template <size_t N> struct fixed_string {
 	bool correct_flag{true};
 	template <typename T> constexpr fixed_string(const T (&input)[N+1]) noexcept {
 		if constexpr (std::is_same_v<T, char>) {
-			#if CTRE_STRING_IS_UTF8
+			#ifdef CTRE_STRING_IS_UTF8
 				size_t out{0};
 				for (size_t i{0}; i < N; ++i) {
 					if ((i == (N-1)) && (input[i] == 0)) break;

--- a/include/ctll/fixed_string.hpp
+++ b/include/ctll/fixed_string.hpp
@@ -209,10 +209,4 @@ template <size_t N> fixed_string(fixed_string<N>) -> fixed_string<N>;
 
 }
 
-#if CTLL_CNTTP_COMPILER_CHECK
-	#define CTLL_FIXED_STRING ctll::fixed_string
-#else
-	#define CTLL_FIXED_STRING const auto &
-#endif
-
 #endif

--- a/include/ctll/utilities.hpp
+++ b/include/ctll/utilities.hpp
@@ -3,7 +3,23 @@
 
 #include <type_traits>
 
-#define CTLL_CNTTP_COMPILER_CHECK (__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L) || ((__cpp_nontype_template_args >= 201411L) && (__clang_major__ >= 12) && !__apple_build_version__))
+#if defined __cpp_nontype_template_parameter_class
+    #define CTLL_CNTTP_COMPILER_CHECK 1
+#elif defined __cpp_nontype_template_args
+    #if __cpp_nontype_template_args >= 201911L
+        #define CTLL_CNTTP_COMPILER_CHECK 1
+    #elif __cpp_nontype_template_args >= 201411L
+        #if defined __clang_major__ && __clang_major__ >= 12
+            #if !defined __apple_build_version__ || !__apple_build_version__
+                #define CTLL_CNTTP_COMPILER_CHECK 1
+            #endif
+        #endif
+    #endif
+#endif
+
+#ifndef CTLL_CNTTP_COMPILER_CHECK
+    #define CTLL_CNTTP_COMPILER_CHECK 0
+#endif
 
 #ifdef _MSC_VER
 #define CTLL_FORCE_INLINE __forceinline

--- a/include/ctre/range.hpp
+++ b/include/ctre/range.hpp
@@ -133,7 +133,7 @@ template <typename... Ts> constexpr bool is_range<multi_subject_range<Ts...>> = 
 
 }
 
-#if __cpp_lib_ranges >= 201911
+#if defined __cpp_lib_ranges && __cpp_lib_ranges >= 201911
 namespace std::ranges {
 
 	template <typename... Ts> inline constexpr bool enable_borrowed_range<::ctre::regex_range<Ts...>> = true;

--- a/include/ctre/utility.hpp
+++ b/include/ctre/utility.hpp
@@ -1,7 +1,9 @@
 #ifndef CTRE__UTILITY__HPP
 #define CTRE__UTILITY__HPP
 
-#define CTRE_CNTTP_COMPILER_CHECK (__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L) || ((__cpp_nontype_template_args >= 201411L) && (__clang_major__ >= 12) && !__apple_build_version__))
+#include "../ctll/utilities.hpp"
+
+#define CTRE_CNTTP_COMPILER_CHECK CTLL_CNTTP_COMPILER_CHECK
 
 #if __GNUC__ > 9
 #if __has_cpp_attribute(likely)

--- a/single-header/ctre-unicode.hpp
+++ b/single-header/ctre-unicode.hpp
@@ -4800,7 +4800,7 @@ template <typename... Ts> constexpr bool is_range<multi_subject_range<Ts...>> = 
 
 }
 
-#if __cpp_lib_ranges >= 201911
+#if defined __cpp_lib_ranges && __cpp_lib_ranges >= 201911
 namespace std::ranges {
 
 	template <typename... Ts> inline constexpr bool enable_borrowed_range<::ctre::regex_range<Ts...>> = true;

--- a/single-header/ctre-unicode.hpp
+++ b/single-header/ctre-unicode.hpp
@@ -444,12 +444,6 @@ template <size_t N> fixed_string(fixed_string<N>) -> fixed_string<N>;
 
 }
 
-#if CTLL_CNTTP_COMPILER_CHECK
-	#define CTLL_FIXED_STRING ctll::fixed_string
-#else
-	#define CTLL_FIXED_STRING const auto &
-#endif
-
 #endif
 
 #ifndef CTLL__TYPE_STACK__HPP

--- a/single-header/ctre-unicode.hpp
+++ b/single-header/ctre-unicode.hpp
@@ -454,7 +454,23 @@ template <size_t N> fixed_string(fixed_string<N>) -> fixed_string<N>;
 
 #include <type_traits>
 
-#define CTLL_CNTTP_COMPILER_CHECK (__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L) || ((__cpp_nontype_template_args >= 201411L) && (__clang_major__ >= 12) && !__apple_build_version__))
+#if defined __cpp_nontype_template_parameter_class
+    #define CTLL_CNTTP_COMPILER_CHECK 1
+#elif defined __cpp_nontype_template_args
+    #if __cpp_nontype_template_args >= 201911L
+        #define CTLL_CNTTP_COMPILER_CHECK 1
+    #elif __cpp_nontype_template_args >= 201411L
+        #if defined __clang_major__ && __clang_major__ >= 12
+            #if !defined __apple_build_version__ || !__apple_build_version__
+                #define CTLL_CNTTP_COMPILER_CHECK 1
+            #endif
+        #endif
+    #endif
+#endif
+
+#ifndef CTLL_CNTTP_COMPILER_CHECK
+    #define CTLL_CNTTP_COMPILER_CHECK 0
+#endif
 
 #ifdef _MSC_VER
 #define CTLL_FORCE_INLINE __forceinline
@@ -1334,7 +1350,7 @@ struct pcre {
 #ifndef CTRE__UTILITY__HPP
 #define CTRE__UTILITY__HPP
 
-#define CTRE_CNTTP_COMPILER_CHECK (__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L) || ((__cpp_nontype_template_args >= 201411L) && (__clang_major__ >= 12) && !__apple_build_version__))
+#define CTRE_CNTTP_COMPILER_CHECK CTLL_CNTTP_COMPILER_CHECK
 
 #if __GNUC__ > 9
 #if __has_cpp_attribute(likely)

--- a/single-header/ctre-unicode.hpp
+++ b/single-header/ctre-unicode.hpp
@@ -277,7 +277,7 @@ template <size_t N> struct fixed_string {
 	bool correct_flag{true};
 	template <typename T> constexpr fixed_string(const T (&input)[N+1]) noexcept {
 		if constexpr (std::is_same_v<T, char>) {
-			#if CTRE_STRING_IS_UTF8
+			#ifdef CTRE_STRING_IS_UTF8
 				size_t out{0};
 				for (size_t i{0}; i < N; ++i) {
 					if ((i == (N-1)) && (input[i] == 0)) break;

--- a/single-header/ctre.hpp
+++ b/single-header/ctre.hpp
@@ -441,12 +441,6 @@ template <size_t N> fixed_string(fixed_string<N>) -> fixed_string<N>;
 
 }
 
-#if CTLL_CNTTP_COMPILER_CHECK
-	#define CTLL_FIXED_STRING ctll::fixed_string
-#else
-	#define CTLL_FIXED_STRING const auto &
-#endif
-
 #endif
 
 #ifndef CTLL__TYPE_STACK__HPP

--- a/single-header/ctre.hpp
+++ b/single-header/ctre.hpp
@@ -274,7 +274,7 @@ template <size_t N> struct fixed_string {
 	bool correct_flag{true};
 	template <typename T> constexpr fixed_string(const T (&input)[N+1]) noexcept {
 		if constexpr (std::is_same_v<T, char>) {
-			#if CTRE_STRING_IS_UTF8
+			#ifdef CTRE_STRING_IS_UTF8
 				size_t out{0};
 				for (size_t i{0}; i < N; ++i) {
 					if ((i == (N-1)) && (input[i] == 0)) break;

--- a/single-header/ctre.hpp
+++ b/single-header/ctre.hpp
@@ -451,7 +451,23 @@ template <size_t N> fixed_string(fixed_string<N>) -> fixed_string<N>;
 
 #include <type_traits>
 
-#define CTLL_CNTTP_COMPILER_CHECK (__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L) || ((__cpp_nontype_template_args >= 201411L) && (__clang_major__ >= 12) && !__apple_build_version__))
+#if defined __cpp_nontype_template_parameter_class
+    #define CTLL_CNTTP_COMPILER_CHECK 1
+#elif defined __cpp_nontype_template_args
+    #if __cpp_nontype_template_args >= 201911L
+        #define CTLL_CNTTP_COMPILER_CHECK 1
+    #elif __cpp_nontype_template_args >= 201411L
+        #if defined __clang_major__ && __clang_major__ >= 12
+            #if !defined __apple_build_version__ || !__apple_build_version__
+                #define CTLL_CNTTP_COMPILER_CHECK 1
+            #endif
+        #endif
+    #endif
+#endif
+
+#ifndef CTLL_CNTTP_COMPILER_CHECK
+    #define CTLL_CNTTP_COMPILER_CHECK 0
+#endif
 
 #ifdef _MSC_VER
 #define CTLL_FORCE_INLINE __forceinline
@@ -1331,7 +1347,7 @@ struct pcre {
 #ifndef CTRE__UTILITY__HPP
 #define CTRE__UTILITY__HPP
 
-#define CTRE_CNTTP_COMPILER_CHECK (__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L) || ((__cpp_nontype_template_args >= 201411L) && (__clang_major__ >= 12) && !__apple_build_version__))
+#define CTRE_CNTTP_COMPILER_CHECK CTLL_CNTTP_COMPILER_CHECK
 
 #if __GNUC__ > 9
 #if __has_cpp_attribute(likely)

--- a/single-header/ctre.hpp
+++ b/single-header/ctre.hpp
@@ -4797,7 +4797,7 @@ template <typename... Ts> constexpr bool is_range<multi_subject_range<Ts...>> = 
 
 }
 
-#if __cpp_lib_ranges >= 201911
+#if defined __cpp_lib_ranges && __cpp_lib_ranges >= 201911
 namespace std::ranges {
 
 	template <typename... Ts> inline constexpr bool enable_borrowed_range<::ctre::regex_range<Ts...>> = true;


### PR DESCRIPTION
The goal of this PR is to make it possible to compile `ctre.hpp` cleanly in the projects that build with `-Wundef`, which is especially important if they also use `-Werror`, as `-Wundef` warnings can't be disabled outside the header using the usual diagnostic pragmas due to a well-known gcc [bug](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53431).

I've tested this with gcc 11 and clang 12 under Linux only so far.