### PR TITLE
-Werror=sign-conversion on GCC 10.2 and C4702: unreachable code on MSVC 16.9.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ tests/benchmark-range/*
 !tests/benchmark-range/*.cpp
 !tests/benchmark-range/*.hpp
 build
+cmake-build-*/*
+.idea/*

--- a/include/ctre/first.hpp
+++ b/include/ctre/first.hpp
@@ -398,10 +398,10 @@ template <size_t Capacity> class point_set {
 		auto first = begin();
 		auto last = end();
 		auto it = first;
-		size_t count = std::distance(first, last);
-		while (count > 0) {
+		auto count = std::distance(first, last);
+                while (count != 0) {
 			it = first;
-			size_t step = count / 2;
+			auto step = count / 2;
 			std::advance(it, step);
 			if (*it < obj) {
 				first = ++it;

--- a/include/ctre/return_type.hpp
+++ b/include/ctre/return_type.hpp
@@ -127,8 +127,9 @@ template <size_t Id, typename Name = void> struct captured_content {
 			} else {
 				return std::basic_string<char_type>(begin(), end());
 			}
-			#endif
-			return std::basic_string<char_type>(begin(), end());
+			#else
+                        return std::basic_string<char_type>(begin(), end());
+                        #endif
 		}
 		
 		constexpr CTRE_FORCE_INLINE auto view() const noexcept {

--- a/include/ctre/return_type.hpp
+++ b/include/ctre/return_type.hpp
@@ -97,8 +97,9 @@ template <size_t Id, typename Name = void> struct captured_content {
 			} else {
 				return static_cast<size_t>(std::distance(begin(), end()));
 			}
+                        #else
+                        return static_cast<size_t>(std::distance(begin(), end()));
 			#endif
-			return static_cast<size_t>(std::distance(begin(), end()));
 		}
 		
 #if __has_include(<charconv>)

--- a/include/ctre/return_type.hpp
+++ b/include/ctre/return_type.hpp
@@ -97,8 +97,8 @@ template <size_t Id, typename Name = void> struct captured_content {
 			} else {
 				return static_cast<size_t>(std::distance(begin(), end()));
 			}
-                        #else
-                        return static_cast<size_t>(std::distance(begin(), end()));
+			#else
+			return static_cast<size_t>(std::distance(begin(), end()));
 			#endif
 		}
 		
@@ -128,8 +128,8 @@ template <size_t Id, typename Name = void> struct captured_content {
 				return std::basic_string<char_type>(begin(), end());
 			}
 			#else
-                        return std::basic_string<char_type>(begin(), end());
-                        #endif
+			return std::basic_string<char_type>(begin(), end());
+			#endif
 		}
 		
 		constexpr CTRE_FORCE_INLINE auto view() const noexcept {

--- a/single-header/ctre-unicode.hpp
+++ b/single-header/ctre-unicode.hpp
@@ -3004,8 +3004,9 @@ template <size_t Id, typename Name = void> struct captured_content {
 			} else {
 				return static_cast<size_t>(std::distance(begin(), end()));
 			}
-			#endif
+			#else
 			return static_cast<size_t>(std::distance(begin(), end()));
+			#endif
 		}
 		
 #if __has_include(<charconv>)
@@ -3033,8 +3034,9 @@ template <size_t Id, typename Name = void> struct captured_content {
 			} else {
 				return std::basic_string<char_type>(begin(), end());
 			}
-			#endif
+			#else
 			return std::basic_string<char_type>(begin(), end());
+			#endif
 		}
 		
 		constexpr CTRE_FORCE_INLINE auto view() const noexcept {
@@ -3834,10 +3836,10 @@ template <size_t Capacity> class point_set {
 		auto first = begin();
 		auto last = end();
 		auto it = first;
-		size_t count = std::distance(first, last);
-		while (count > 0) {
+		auto count = std::distance(first, last);
+                while (count != 0) {
 			it = first;
-			size_t step = count / 2;
+			auto step = count / 2;
 			std::advance(it, step);
 			if (*it < obj) {
 				first = ++it;

--- a/single-header/ctre.hpp
+++ b/single-header/ctre.hpp
@@ -3001,8 +3001,9 @@ template <size_t Id, typename Name = void> struct captured_content {
 			} else {
 				return static_cast<size_t>(std::distance(begin(), end()));
 			}
-			#endif
+			#else
 			return static_cast<size_t>(std::distance(begin(), end()));
+			#endif
 		}
 		
 #if __has_include(<charconv>)
@@ -3030,8 +3031,9 @@ template <size_t Id, typename Name = void> struct captured_content {
 			} else {
 				return std::basic_string<char_type>(begin(), end());
 			}
-			#endif
+			#else
 			return std::basic_string<char_type>(begin(), end());
+			#endif
 		}
 		
 		constexpr CTRE_FORCE_INLINE auto view() const noexcept {
@@ -3831,10 +3833,10 @@ template <size_t Capacity> class point_set {
 		auto first = begin();
 		auto last = end();
 		auto it = first;
-		size_t count = std::distance(first, last);
-		while (count > 0) {
+		auto count = std::distance(first, last);
+                while (count != 0) {
 			it = first;
-			size_t step = count / 2;
+			auto step = count / 2;
 			std::advance(it, step);
 			if (*it < obj) {
 				first = ++it;


### PR DESCRIPTION
## std::distance of pointers returns long int -Werror=sign-conversion on GCC 10.2
In this code we were implicitly casting the return value of `std::distance` to `size_t`. I was originally going to add a `static_cast<size_t>`. Then decided we could change `count` and `step` to `auto`. This seems to work fine.

I also changed the `>0` to `!=0`. From what I could tell count can never be less than zero.
```c++
//before
size_t count = std::distance(first, last);
while (count > 0) {
size_t step = count / 2;
//after		
auto count = std::distance(first, last);
while (count != 0) {
auto step = count / 2;
```
```shell
_deps/ctre_fetch-src/include/ctre/first.hpp:357:31: error: conversion to â€˜size_tâ€™ {aka â€˜long unsigned intâ€™} from â€˜std::iterator_traits<ctre::point_set<1>::point*>::difference_typeâ€™ {aka â€˜long intâ€™} may change the sign of the result [-Werror=sign-conversion]
```

[GodBolt](https://godbolt.org/z/KhM6r1ocj)
## C4702: unreachable code MSVC 16.9.6
Sorry for not branching again. I'm doing fixes to keep my local code compiling.
```c++
//before
#endif
return static_cast<size_t>(std::distance(begin(), end()));
//after
#else
return static_cast<size_t>(std::distance(begin(), end()));
#endif
```
```shell
D:\dev\OpenVIII_CPP_WIP\cmake-build-debug-visual-studio\_deps\ctre_fetch-src\include\ctre\return_type.hpp(101) : error C2220: the following warning is treated as an error
D:\dev\OpenVIII_CPP_WIP\cmake-build-debug-visual-studio\_deps\ctre_fetch-src\include\ctre\return_type.hpp(101) : warning C4702: unreachable code
D:\dev\OpenVIII_CPP_WIP\cmake-build-debug-visual-studio\_deps\ctre_fetch-src\include\ctre\return_type.hpp(101) : warning C4702: unreachable code
D:\dev\OpenVIII_CPP_WIP\cmake-build-debug-visual-studio\_deps\ctre_fetch-src\include\ctre\return_type.hpp(101) : warning C4702: unreachable code
```
Spotted a second instance of this for when you call `to_string()`

```c++
//before
#endif
return std::basic_string<char_type>(begin(), end());
//after
#else
return std::basic_string<char_type>(begin(), end());
#endif
```

```shell
D:\dev\OpenVIII_CPP_WIP\cmake-build-debug-visual-studio\_deps\ctre_fetch-src\include\ctre\return_type.hpp(131) : error C2220: the following warning is treated as an error
D:\dev\OpenVIII_CPP_WIP\cmake-build-debug-visual-studio\_deps\ctre_fetch-src\include\ctre\return_type.hpp(131) : warning C4702: unreachable code
```