### PR TITLE
-Wold-style-cast GCC 10.2

### DIFF
--- a/include/ctre/actions/hexdec.inc.hpp
+++ b/include/ctre/actions/hexdec.inc.hpp
@@ -20,9 +20,9 @@ template <auto V, size_t N, typename... Ts, typename Parameters> static constexp
 template <auto V, size_t N, typename... Ts, typename Parameters> static constexpr auto apply(pcre::finish_hexdec, ctll::term<V>, pcre_context<ctll::list<number<N>, Ts...>, Parameters> subject) {
 	constexpr size_t max_char = std::numeric_limits<char>::max();
 	if constexpr (N <= max_char) {
-		return pcre_context{ctll::push_front(character<(char)N>(), ctll::list<Ts...>()), subject.parameters};
+		return pcre_context{ctll::push_front(character<char{N}>(), ctll::list<Ts...>()), subject.parameters};
 	} else {
-		return pcre_context{ctll::push_front(character<(char32_t)N>(), ctll::list<Ts...>()), subject.parameters};
+		return pcre_context{ctll::push_front(character<char32_t{N}>(), ctll::list<Ts...>()), subject.parameters};
 	} 
 }	
 

--- a/include/ctre/atoms_characters.hpp
+++ b/include/ctre/atoms_characters.hpp
@@ -54,35 +54,35 @@ using word_chars = set<char_range<'A','Z'>, char_range<'a','z'>, char_range<'0',
 using space_chars = enumeration<' ', '\t', '\n', '\v', '\f', '\r'>;
 
 using vertical_space_chars = enumeration<
-	(char)0x000A, // Linefeed (LF)
-	(char)0x000B, // Vertical tab (VT)
-	(char)0x000C, // Form feed (FF)
-	(char)0x000D, // Carriage return (CR)
-	(char32_t)0x0085, // Next line (NEL)
-	(char32_t)0x2028, // Line separator
-	(char32_t)0x2029 // Paragraph separator
+	char{0x000A}, // Linefeed (LF)
+	char{0x000B}, // Vertical tab (VT)
+	char{0x000C}, // Form feed (FF)
+	char{0x000D}, // Carriage return (CR)
+	char32_t{0x0085}, // Next line (NEL)
+	char32_t{0x2028}, // Line separator
+	char32_t{0x2029} // Paragraph separator
 >;
 
 using horizontal_space_chars = enumeration<
-    (char)0x0009, // Horizontal tab (HT)
-    (char)0x0020, // Space
-    (char32_t)0x00A0, // Non-break space
-    (char32_t)0x1680, // Ogham space mark
-    (char32_t)0x180E, // Mongolian vowel separator
-    (char32_t)0x2000, // En quad
-    (char32_t)0x2001, // Em quad
-    (char32_t)0x2002, // En space
-    (char32_t)0x2003, // Em space
-    (char32_t)0x2004, // Three-per-em space
-    (char32_t)0x2005, // Four-per-em space
-    (char32_t)0x2006, // Six-per-em space
-    (char32_t)0x2007, // Figure space
-    (char32_t)0x2008, // Punctuation space
-    (char32_t)0x2009, // Thin space
-    (char32_t)0x200A, // Hair space
-    (char32_t)0x202F, // Narrow no-break space
-    (char32_t)0x205F, // Medium mathematical space
-    (char32_t)0x3000 // Ideographic space
+    char{0x0009}, // Horizontal tab (HT)
+    char{0x0020}, // Space
+    char32_t{0x00A0}, // Non-break space
+    char32_t{0x1680}, // Ogham space mark
+    char32_t{0x180E}, // Mongolian vowel separator
+    char32_t{0x2000}, // En quad
+    char32_t{0x2001}, // Em quad
+    char32_t{0x2002}, // En space
+    char32_t{0x2003}, // Em space
+    char32_t{0x2004}, // Three-per-em space
+    char32_t{0x2005}, // Four-per-em space
+    char32_t{0x2006}, // Six-per-em space
+    char32_t{0x2007}, // Figure space
+    char32_t{0x2008}, // Punctuation space
+    char32_t{0x2009}, // Thin space
+    char32_t{0x200A}, // Hair space
+    char32_t{0x202F}, // Narrow no-break space
+    char32_t{0x205F}, // Medium mathematical space
+    char32_t{0x3000} // Ideographic space
 >;
 
 using alphanum_chars = set<char_range<'A','Z'>, char_range<'a','z'>, char_range<'0','9'> >;

--- a/single-header/ctre-unicode.hpp
+++ b/single-header/ctre-unicode.hpp
@@ -1429,35 +1429,35 @@ using word_chars = set<char_range<'A','Z'>, char_range<'a','z'>, char_range<'0',
 using space_chars = enumeration<' ', '\t', '\n', '\v', '\f', '\r'>;
 
 using vertical_space_chars = enumeration<
-	(char)0x000A, // Linefeed (LF)
-	(char)0x000B, // Vertical tab (VT)
-	(char)0x000C, // Form feed (FF)
-	(char)0x000D, // Carriage return (CR)
-	(char32_t)0x0085, // Next line (NEL)
-	(char32_t)0x2028, // Line separator
-	(char32_t)0x2029 // Paragraph separator
+	char{0x000A}, // Linefeed (LF)
+	char{0x000B}, // Vertical tab (VT)
+	char{0x000C}, // Form feed (FF)
+	char{0x000D}, // Carriage return (CR)
+	char32_t{0x0085}, // Next line (NEL)
+	char32_t{0x2028}, // Line separator
+	char32_t{0x2029} // Paragraph separator
 >;
 
 using horizontal_space_chars = enumeration<
-    (char)0x0009, // Horizontal tab (HT)
-    (char)0x0020, // Space
-    (char32_t)0x00A0, // Non-break space
-    (char32_t)0x1680, // Ogham space mark
-    (char32_t)0x180E, // Mongolian vowel separator
-    (char32_t)0x2000, // En quad
-    (char32_t)0x2001, // Em quad
-    (char32_t)0x2002, // En space
-    (char32_t)0x2003, // Em space
-    (char32_t)0x2004, // Three-per-em space
-    (char32_t)0x2005, // Four-per-em space
-    (char32_t)0x2006, // Six-per-em space
-    (char32_t)0x2007, // Figure space
-    (char32_t)0x2008, // Punctuation space
-    (char32_t)0x2009, // Thin space
-    (char32_t)0x200A, // Hair space
-    (char32_t)0x202F, // Narrow no-break space
-    (char32_t)0x205F, // Medium mathematical space
-    (char32_t)0x3000 // Ideographic space
+    char{0x0009}, // Horizontal tab (HT)
+    char{0x0020}, // Space
+    char32_t{0x00A0}, // Non-break space
+    char32_t{0x1680}, // Ogham space mark
+    char32_t{0x180E}, // Mongolian vowel separator
+    char32_t{0x2000}, // En quad
+    char32_t{0x2001}, // Em quad
+    char32_t{0x2002}, // En space
+    char32_t{0x2003}, // Em space
+    char32_t{0x2004}, // Three-per-em space
+    char32_t{0x2005}, // Four-per-em space
+    char32_t{0x2006}, // Six-per-em space
+    char32_t{0x2007}, // Figure space
+    char32_t{0x2008}, // Punctuation space
+    char32_t{0x2009}, // Thin space
+    char32_t{0x200A}, // Hair space
+    char32_t{0x202F}, // Narrow no-break space
+    char32_t{0x205F}, // Medium mathematical space
+    char32_t{0x3000} // Ideographic space
 >;
 
 using alphanum_chars = set<char_range<'A','Z'>, char_range<'a','z'>, char_range<'0','9'> >;
@@ -2169,9 +2169,9 @@ template <auto V, size_t N, typename... Ts, typename Parameters> static constexp
 template <auto V, size_t N, typename... Ts, typename Parameters> static constexpr auto apply(pcre::finish_hexdec, ctll::term<V>, pcre_context<ctll::list<number<N>, Ts...>, Parameters> subject) {
 	constexpr size_t max_char = std::numeric_limits<char>::max();
 	if constexpr (N <= max_char) {
-		return pcre_context{ctll::push_front(character<(char)N>(), ctll::list<Ts...>()), subject.parameters};
+		return pcre_context{ctll::push_front(character<char{N}>(), ctll::list<Ts...>()), subject.parameters};
 	} else {
-		return pcre_context{ctll::push_front(character<(char32_t)N>(), ctll::list<Ts...>()), subject.parameters};
+		return pcre_context{ctll::push_front(character<char32_t{N}>(), ctll::list<Ts...>()), subject.parameters};
 	} 
 }	
 

--- a/single-header/ctre.hpp
+++ b/single-header/ctre.hpp
@@ -1426,35 +1426,35 @@ using word_chars = set<char_range<'A','Z'>, char_range<'a','z'>, char_range<'0',
 using space_chars = enumeration<' ', '\t', '\n', '\v', '\f', '\r'>;
 
 using vertical_space_chars = enumeration<
-	(char)0x000A, // Linefeed (LF)
-	(char)0x000B, // Vertical tab (VT)
-	(char)0x000C, // Form feed (FF)
-	(char)0x000D, // Carriage return (CR)
-	(char32_t)0x0085, // Next line (NEL)
-	(char32_t)0x2028, // Line separator
-	(char32_t)0x2029 // Paragraph separator
+	char{0x000A}, // Linefeed (LF)
+	char{0x000B}, // Vertical tab (VT)
+	char{0x000C}, // Form feed (FF)
+	char{0x000D}, // Carriage return (CR)
+	char32_t{0x0085}, // Next line (NEL)
+	char32_t{0x2028}, // Line separator
+	char32_t{0x2029} // Paragraph separator
 >;
 
 using horizontal_space_chars = enumeration<
-    (char)0x0009, // Horizontal tab (HT)
-    (char)0x0020, // Space
-    (char32_t)0x00A0, // Non-break space
-    (char32_t)0x1680, // Ogham space mark
-    (char32_t)0x180E, // Mongolian vowel separator
-    (char32_t)0x2000, // En quad
-    (char32_t)0x2001, // Em quad
-    (char32_t)0x2002, // En space
-    (char32_t)0x2003, // Em space
-    (char32_t)0x2004, // Three-per-em space
-    (char32_t)0x2005, // Four-per-em space
-    (char32_t)0x2006, // Six-per-em space
-    (char32_t)0x2007, // Figure space
-    (char32_t)0x2008, // Punctuation space
-    (char32_t)0x2009, // Thin space
-    (char32_t)0x200A, // Hair space
-    (char32_t)0x202F, // Narrow no-break space
-    (char32_t)0x205F, // Medium mathematical space
-    (char32_t)0x3000 // Ideographic space
+    char{0x0009}, // Horizontal tab (HT)
+    char{0x0020}, // Space
+    char32_t{0x00A0}, // Non-break space
+    char32_t{0x1680}, // Ogham space mark
+    char32_t{0x180E}, // Mongolian vowel separator
+    char32_t{0x2000}, // En quad
+    char32_t{0x2001}, // Em quad
+    char32_t{0x2002}, // En space
+    char32_t{0x2003}, // Em space
+    char32_t{0x2004}, // Three-per-em space
+    char32_t{0x2005}, // Four-per-em space
+    char32_t{0x2006}, // Six-per-em space
+    char32_t{0x2007}, // Figure space
+    char32_t{0x2008}, // Punctuation space
+    char32_t{0x2009}, // Thin space
+    char32_t{0x200A}, // Hair space
+    char32_t{0x202F}, // Narrow no-break space
+    char32_t{0x205F}, // Medium mathematical space
+    char32_t{0x3000} // Ideographic space
 >;
 
 using alphanum_chars = set<char_range<'A','Z'>, char_range<'a','z'>, char_range<'0','9'> >;
@@ -2166,9 +2166,9 @@ template <auto V, size_t N, typename... Ts, typename Parameters> static constexp
 template <auto V, size_t N, typename... Ts, typename Parameters> static constexpr auto apply(pcre::finish_hexdec, ctll::term<V>, pcre_context<ctll::list<number<N>, Ts...>, Parameters> subject) {
 	constexpr size_t max_char = std::numeric_limits<char>::max();
 	if constexpr (N <= max_char) {
-		return pcre_context{ctll::push_front(character<(char)N>(), ctll::list<Ts...>()), subject.parameters};
+		return pcre_context{ctll::push_front(character<char{N}>(), ctll::list<Ts...>()), subject.parameters};
 	} else {
-		return pcre_context{ctll::push_front(character<(char32_t)N>(), ctll::list<Ts...>()), subject.parameters};
+		return pcre_context{ctll::push_front(character<char32_t{N}>(), ctll::list<Ts...>()), subject.parameters};
 	} 
 }	
 

--- a/tests/generating.cpp
+++ b/tests/generating.cpp
@@ -50,14 +50,14 @@ static_assert(same_f(CTRE_GEN("abc"), ctre::string<'a','b','c'>()));
 static_assert(same_f(CTRE_GEN("(?:abc)"), ctre::string<'a','b','c'>()));
 
 // support for hexdec
-static_assert(same_f(CTRE_GEN("\\x40"), ctre::character<(char)0x40>()));
-static_assert(same_f(CTRE_GEN("\\x7F"), ctre::character<(char)0x7F>()));
+static_assert(same_f(CTRE_GEN("\\x40"), ctre::character<char{0x40}>()));
+static_assert(same_f(CTRE_GEN("\\x7F"), ctre::character<char{0x7F}>()));
 // only characters with value < 128 are char otherwise they are internally char32_t
-static_assert(same_f(CTRE_GEN("\\x80"), ctre::character<(char32_t)0x80>()));
-static_assert(same_f(CTRE_GEN("\\xFF"), ctre::character<(char32_t)0xFF>()));
-static_assert(same_f(CTRE_GEN("\\x{FF}"), ctre::character<(char32_t)0xFF>()));
-static_assert(same_f(CTRE_GEN("\\x{FFF}"), ctre::character<(char32_t)0xFFF>()));
-static_assert(same_f(CTRE_GEN("\\x{ABCD}"), ctre::character<(char32_t)0xABCD>()));
+static_assert(same_f(CTRE_GEN("\\x80"), ctre::character<char32_t{0x80}>()));
+static_assert(same_f(CTRE_GEN("\\xFF"), ctre::character<char32_t{0xFF}>()));
+static_assert(same_f(CTRE_GEN("\\x{FF}"), ctre::character<char32_t{0xFF}>()));
+static_assert(same_f(CTRE_GEN("\\x{FFF}"), ctre::character<char32_t{0xFFF}>()));
+static_assert(same_f(CTRE_GEN("\\x{ABCD}"), ctre::character<char32_t{0xABCD}>()));
 
 // anything
 static_assert(same_f(CTRE_GEN("."), ctre::any()));


### PR DESCRIPTION
I added `-Wold-style-cast` to the makefile and ran make.
I changed things like `(char)0x0040` to `char{0x0040}`. Jason said something about this style on his stream.

Tests compiled on gcc 10.2 so I think we're okay. It was either this or `static_cast<>`