### PR TITLE
patch calculate_size_of_first which is creating issues with embedded sets

### DIFF
--- a/include/ctre/first.hpp
+++ b/include/ctre/first.hpp
@@ -282,7 +282,7 @@ template <typename... Content> constexpr auto calculate_first(Content...) noexce
 
 // calculate mutual exclusivity
 template <typename... Content> constexpr size_t calculate_size_of_first(ctre::negative_set<Content...>) {
-	return 1 + 1 * sizeof...(Content);
+	return 1 + calculate_size_of_first(ctre::set<Content...>{});
 }
 
 template <auto... V> constexpr size_t calculate_size_of_first(ctre::enumeration<V...>) {

--- a/single-header/ctre-unicode.hpp
+++ b/single-header/ctre-unicode.hpp
@@ -3722,7 +3722,7 @@ template <typename... Content> constexpr auto calculate_first(Content...) noexce
 
 // calculate mutual exclusivity
 template <typename... Content> constexpr size_t calculate_size_of_first(ctre::negative_set<Content...>) {
-	return 1 + 1 * sizeof...(Content);
+	return 1 + calculate_size_of_first(ctre::set<Content...>{});
 }
 
 template <auto... V> constexpr size_t calculate_size_of_first(ctre::enumeration<V...>) {

--- a/single-header/ctre.hpp
+++ b/single-header/ctre.hpp
@@ -3719,7 +3719,7 @@ template <typename... Content> constexpr auto calculate_first(Content...) noexce
 
 // calculate mutual exclusivity
 template <typename... Content> constexpr size_t calculate_size_of_first(ctre::negative_set<Content...>) {
-	return 1 + 1 * sizeof...(Content);
+	return 1 + calculate_size_of_first(ctre::set<Content...>{});
 }
 
 template <auto... V> constexpr size_t calculate_size_of_first(ctre::enumeration<V...>) {


### PR DESCRIPTION
Should solve #199 and #175

Issue stems from ctre::word_chars being a set*, when processed as part of the regex the current method massively undercounts the needed capacity.