### PR TITLE
patch: optimize selects by extracting exclusive branches

### DIFF
--- a/include/ctll/list.hpp
+++ b/include/ctll/list.hpp
@@ -61,6 +61,8 @@ template <typename T> struct item_matcher {
 	static constexpr auto check(...) { return std::false_type{}; }
 	static constexpr auto select(T) { return not_selected{}; }
 	template <typename Y> static constexpr auto select(Y) { return wrapper<Y>{}; }
+	static constexpr auto pick(std::true_type) { return wrapper<Y>{}; };
+	static constexpr auto pick(std::false_type) { return not_selected{}; };
 };
 
 template <typename T, typename... Ts> constexpr bool exists_in(T, list<Ts...>) noexcept {

--- a/include/ctre/atoms.hpp
+++ b/include/ctre/atoms.hpp
@@ -20,6 +20,7 @@ struct any { };
 // actual AST of regexp
 template <auto... Str> struct string { };
 template <typename... Opts> struct select { };
+template <typename... Opts> struct non_exclusive_select { };
 template <typename... Content> struct sequence { };
 struct empty { };
 


### PR DESCRIPTION
Should supersede #158, actually extracts mutually exclusive paths.

EG: in lexer example, it'll recognize that "([a-z]+)|([0-9]+)" has mutually exclusive paths and will split them apart from one another based on the first character. In theory should reduce runtimes, needs testing.