### PR TITLE
fix several compiler errors when using msvc with unicode headers

### DIFF
--- a/include/ctre/atoms_unicode.hpp
+++ b/include/ctre/atoms_unicode.hpp
@@ -3,6 +3,7 @@
 
 // master branch is not including unicode db (for now)
 #include "../unicode-db/unicode_interface.hpp"
+#include <type_traits>
 
 namespace ctre {
 
@@ -18,11 +19,11 @@ template <size_t Sz> constexpr std::string_view get_string_view(const char (& ar
 
 // basic support for binary and type-value properties
 
-template <auto Name> struct binary_property;
+template <typename Name, Name> struct binary_property_;
 template <auto Name, auto Value> struct property;
 
 // unicode TS#18 level 1.2 general_category
-template <uni::detail::binary_prop Property> struct binary_property<Property> {
+template <uni::detail::binary_prop Property> struct binary_property_<uni::detail::binary_prop, Property> {
 	template <typename CharT> inline static constexpr bool match_char(CharT c) noexcept {
 		return uni::detail::get_binary_prop<Property>(c);
 	}
@@ -36,7 +37,7 @@ enum class property_type {
 
 // unicode TS#18 level 1.2.2
 
-template <uni::script Script> struct binary_property<Script> {
+template <uni::script Script> struct binary_property_<uni::script, Script> {
 	template <typename CharT> inline static constexpr bool match_char(CharT c) noexcept {
 		return uni::cp_script(c) == Script;
 	}
@@ -51,17 +52,20 @@ template <uni::script Script> struct property<property_type::script_extension, S
 	}
 };
 
-template <uni::version Age> struct binary_property<Age> {
+template <uni::version Age> struct binary_property_<uni::version, Age> {
 	template <typename CharT> inline static constexpr bool match_char(CharT c) noexcept {
 		return uni::cp_age(c) <= Age;
 	}
 };
 
-template <uni::block Block> struct binary_property<Block> {
+template <uni::block Block> struct binary_property_<uni::block, Block> {
 	template <typename CharT> inline static constexpr bool match_char(CharT c) noexcept {
 		return uni::cp_block(c) == Block;
 	}
 };
+
+template <auto Name>
+using binary_property = binary_property_<std::remove_cv_t<decltype(Name)>, Name>;
 
 // nonbinary properties
 

--- a/include/unicode-db/unicode-db.hpp
+++ b/include/unicode-db/unicode-db.hpp
@@ -341,11 +341,11 @@ constexpr int propcharcomp(char a, char b) {
 
 constexpr int propnamecomp(std::string_view sa, std::string_view sb) {
     // workaround, iterators in std::string_view are not constexpr in libc++ (for now)
-    const char* a = sa.begin();
-    const char* b = sb.begin();
+    const char* a = sa.data();
+    const char* b = sb.data();
 
-    const char* ae = sa.end();
-    const char* be = sb.end();
+    const char* ae = sa.data() + sa.size();
+    const char* be = sb.data() + sb.size();
 
     for(; a != ae && b != be; a++, b++) {
         auto res = propcharcomp(*a, *b);

--- a/include/unicode-db/unicode-db.hpp
+++ b/include/unicode-db/unicode-db.hpp
@@ -68,11 +68,7 @@ namespace uni
     constexpr bool cp_is_ascii(char32_t cp);
     constexpr numeric_value cp_numeric_value(char32_t cp);
 
-    template<script>
-    constexpr bool cp_is(char32_t);
-    template<property>
-    constexpr bool cp_is(char32_t);
-    template<category>
+    template<auto>
     constexpr bool cp_is(char32_t);
 
     namespace detail

--- a/include/unicode-db/unicode_interface.hpp
+++ b/include/unicode-db/unicode_interface.hpp
@@ -66,11 +66,7 @@ namespace uni
     constexpr bool cp_is_ascii(char32_t cp);
     constexpr numeric_value cp_numeric_value(char32_t cp);
 
-    template<script>
-    constexpr bool cp_is(char32_t);
-    template<property>
-    constexpr bool cp_is(char32_t);
-    template<category>
+    template<auto>
     constexpr bool cp_is(char32_t);
 
     namespace detail

--- a/single-header/ctre.hpp
+++ b/single-header/ctre.hpp
@@ -1616,11 +1616,7 @@ namespace uni
     constexpr bool cp_is_ascii(char32_t cp);
     constexpr numeric_value cp_numeric_value(char32_t cp);
 
-    template<script>
-    constexpr bool cp_is(char32_t);
-    template<property>
-    constexpr bool cp_is(char32_t);
-    template<category>
+    template<auto>
     constexpr bool cp_is(char32_t);
 
     namespace detail
@@ -1647,6 +1643,8 @@ namespace uni
 
 #endif
 
+#include <type_traits>
+
 namespace ctre {
 
 // properties name & value
@@ -1660,11 +1658,11 @@ template <size_t Sz> constexpr std::string_view get_string_view(const char (& ar
 
 // basic support for binary and type-value properties
 
-template <auto Name> struct binary_property;
+template <typename Name, Name> struct binary_property_;
 template <auto Name, auto Value> struct property;
 
 // unicode TS#18 level 1.2 general_category
-template <uni::detail::binary_prop Property> struct binary_property<Property> {
+template <uni::detail::binary_prop Property> struct binary_property_<uni::detail::binary_prop, Property> {
 	template <typename CharT> inline static constexpr bool match_char(CharT c) noexcept {
 		return uni::detail::get_binary_prop<Property>(c);
 	}
@@ -1678,7 +1676,7 @@ enum class property_type {
 
 // unicode TS#18 level 1.2.2
 
-template <uni::script Script> struct binary_property<Script> {
+template <uni::script Script> struct binary_property_<uni::script, Script> {
 	template <typename CharT> inline static constexpr bool match_char(CharT c) noexcept {
 		return uni::cp_script(c) == Script;
 	}
@@ -1693,17 +1691,20 @@ template <uni::script Script> struct property<property_type::script_extension, S
 	}
 };
 
-template <uni::version Age> struct binary_property<Age> {
+template <uni::version Age> struct binary_property_<uni::version, Age> {
 	template <typename CharT> inline static constexpr bool match_char(CharT c) noexcept {
 		return uni::cp_age(c) <= Age;
 	}
 };
 
-template <uni::block Block> struct binary_property<Block> {
+template <uni::block Block> struct binary_property_<uni::block, Block> {
 	template <typename CharT> inline static constexpr bool match_char(CharT c) noexcept {
 		return uni::cp_block(c) == Block;
 	}
 };
+
+template <auto Name>
+using binary_property = binary_property_<std::remove_cv_t<decltype(Name)>, Name>;
 
 // nonbinary properties
 

--- a/single-header/unicode-db.hpp
+++ b/single-header/unicode-db.hpp
@@ -68,11 +68,7 @@ namespace uni
     constexpr bool cp_is_ascii(char32_t cp);
     constexpr numeric_value cp_numeric_value(char32_t cp);
 
-    template<script>
-    constexpr bool cp_is(char32_t);
-    template<property>
-    constexpr bool cp_is(char32_t);
-    template<category>
+    template<auto>
     constexpr bool cp_is(char32_t);
 
     namespace detail
@@ -341,11 +337,11 @@ constexpr int propcharcomp(char a, char b) {
 
 constexpr int propnamecomp(std::string_view sa, std::string_view sb) {
     // workaround, iterators in std::string_view are not constexpr in libc++ (for now)
-    const char* a = sa.begin();
-    const char* b = sb.begin();
+    const char* a = sa.data();
+    const char* b = sb.data();
 
-    const char* ae = sa.end();
-    const char* be = sb.end();
+    const char* ae = sa.data() + sa.size();
+    const char* be = sb.data() + sb.size();
 
     for(; a != ae && b != be; a++, b++) {
         auto res = propcharcomp(*a, *b);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,4 +7,8 @@ foreach (source IN LISTS test-sources)
   add_library(ctre-test-${test} STATIC EXCLUDE_FROM_ALL ${source})
   target_link_libraries(ctre-test-${test} PRIVATE ctre)
   add_dependencies(ctre-test ctre-test-${test})
+
+  if (MSVC)
+    target_compile_options(ctre-test-${test} PRIVATE /utf-8)
+  endif()
 endforeach()

--- a/tests/_fixed-string.cpp
+++ b/tests/_fixed-string.cpp
@@ -10,7 +10,7 @@ static_assert(Pattern.size() == 38);
 #ifdef CTRE_STRING_IS_UTF8
 static_assert(ctll::fixed_string("ěšč").size() == 3);
 static_assert(ctll::fixed_string("😍").size() == 1);
-static_assert(ctll::fixed_string("😍")[0] == L'😍');
+static_assert(ctll::fixed_string("😍")[0] == U'😍');
 #else
 static_assert(ctll::fixed_string("ěšč").size() == 6); // it's just a bunch of bytes
 static_assert(ctll::fixed_string("😍").size() == 4); // it's just a bunch of bytes
@@ -20,7 +20,7 @@ static_assert(ctll::fixed_string("😍").size() == 4); // it's just a bunch of b
 // u8"" is utf-8 encoded
 static_assert(ctll::fixed_string(u8"ěšč").size() == 3);
 static_assert(ctll::fixed_string(u8"😍").size() == 1);
-static_assert(ctll::fixed_string(u8"😍")[0] == L'😍');
+static_assert(ctll::fixed_string(u8"😍")[0] == U'😍');
 #endif
 
 // u"" is utf-16


### PR DESCRIPTION
Of particular note is an MSVC bug where it does not include the enum type in a mangled type's name when you use only the value. I managed to work around this by including the enum type in the type name, separately from the value. See [this godbolt link](https://godbolt.org/z/bfszz5aEz) for a simple demonstration of the problem.