### PR TITLE
Remove unnecessary static of not_matched

### DIFF
--- a/include/ctre/return_type.hpp
+++ b/include/ctre/return_type.hpp
@@ -21,7 +21,7 @@ constexpr bool is_random_accessible(...) { return false; }
 
 struct not_matched_tag_t { };
 
-static constexpr inline auto not_matched = not_matched_tag_t{};
+constexpr inline auto not_matched = not_matched_tag_t{};
 	
 template <size_t Id, typename Name = void> struct captured_content {
 	template <typename Iterator> class storage {


### PR DESCRIPTION
static here is unnecessary and duplicates the data in every translation unit.