### PR TITLE
ctre::split a string ends with delimiter may cause undefined behavior, can we use std::to_address to fix it?

### DIFF
--- a/include/ctre/return_type.hpp
+++ b/include/ctre/return_type.hpp
@@ -7,6 +7,7 @@
 #include <tuple>
 #include <string_view>
 #include <string>
+#include <memory>
 #include <iterator>
 #include <iosfwd>
 #if __has_include(<charconv>)
@@ -71,10 +72,18 @@ template <size_t Id, typename Name = void> struct captured_content {
 			if constexpr (std::is_same_v<Iterator, utf8_iterator>) {
 				return _begin.ptr;
 			} else {
+				#if __cpp_lib_to_address >= 201711L
+				return std::to_address(_begin);
+				#else
 				return &*_begin;
+				#endif
 			}
 			#else
+			#if __cpp_lib_to_address >= 201711L
+			return std::to_address(_begin);
+			#else
 			return &*_begin;
+			#endif
 			#endif
 		}
 		

--- a/include/ctre/return_type.hpp
+++ b/include/ctre/return_type.hpp
@@ -7,7 +7,6 @@
 #include <tuple>
 #include <string_view>
 #include <string>
-#include <memory>
 #include <iterator>
 #include <iosfwd>
 #include <memory>

--- a/single-header/ctre-unicode.hpp
+++ b/single-header/ctre-unicode.hpp
@@ -240,6 +240,7 @@ Software.
 #include <cstddef>
 #include <string_view>
 #include <cstdint>
+#include <memory>
 
 namespace ctll {
 
@@ -2978,10 +2979,18 @@ template <size_t Id, typename Name = void> struct captured_content {
 			if constexpr (std::is_same_v<Iterator, utf8_iterator>) {
 				return _begin.ptr;
 			} else {
+				#if __cpp_lib_to_address >= 201711L
+				return std::to_address(_begin);
+				#else
 				return &*_begin;
+				#endif
 			}
 			#else
+			#if __cpp_lib_to_address >= 201711L
+			return std::to_address(_begin);
+			#else
 			return &*_begin;
+			#endif
 			#endif
 		}
 		

--- a/single-header/ctre.hpp
+++ b/single-header/ctre.hpp
@@ -237,6 +237,7 @@ Software.
 #include <cstddef>
 #include <string_view>
 #include <cstdint>
+#include <memory>
 
 namespace ctll {
 
@@ -2975,10 +2976,18 @@ template <size_t Id, typename Name = void> struct captured_content {
 			if constexpr (std::is_same_v<Iterator, utf8_iterator>) {
 				return _begin.ptr;
 			} else {
+				#if __cpp_lib_to_address >= 201711L
+				return std::to_address(_begin);
+				#else
 				return &*_begin;
+				#endif
 			}
 			#else
+			#if __cpp_lib_to_address >= 201711L
+			return std::to_address(_begin);
+			#else
 			return &*_begin;
+			#endif
 			#endif
 		}
 		


### PR DESCRIPTION
When use ctre::split to split a string starts/ends with delimiter, the results starts/ends with empty ctre::regex_results, and the function ctre::regex_results::to_view()/to_number()/to_string() use data_unsafe() to get the address,

> https://github.com/hanickadot/compile-time-regular-expressions/blob/cce1c948de8e3288d277466714ace1669ad02c68/include/ctre/return_type.hpp#L69-L79

so the ends empty ctre::regex_results may cause undefined behavior by```&*_begin``` when use ctre::regex_results::to_view()/to_number()/to_string(), which may be detected by compiler in debug mode.

Here is a screenshot. (Visual Studio 2019, debug mode)

![image](https://user-images.githubusercontent.com/51276909/131886346-c1f05148-45e5-4757-9b49-5c78e7bad796.png)

I think we can replace ```&*_begin``` with ```std::to_address(_begin)``` to fix this problem.
