### PR TITLE
Fix compilation on Clang 12 with -std=c++17

### DIFF
--- a/include/ctll/utilities.hpp
+++ b/include/ctll/utilities.hpp
@@ -8,12 +8,6 @@
 #elif defined __cpp_nontype_template_args
     #if __cpp_nontype_template_args >= 201911L
         #define CTLL_CNTTP_COMPILER_CHECK 1
-    #elif __cpp_nontype_template_args >= 201411L
-        #if defined __clang_major__ && __clang_major__ >= 12
-            #if !defined __apple_build_version__ || !__apple_build_version__
-                #define CTLL_CNTTP_COMPILER_CHECK 1
-            #endif
-        #endif
     #endif
 #endif
 

--- a/single-header/ctre-unicode.hpp
+++ b/single-header/ctre-unicode.hpp
@@ -459,12 +459,6 @@ template <size_t N> fixed_string(fixed_string<N>) -> fixed_string<N>;
 #elif defined __cpp_nontype_template_args
     #if __cpp_nontype_template_args >= 201911L
         #define CTLL_CNTTP_COMPILER_CHECK 1
-    #elif __cpp_nontype_template_args >= 201411L
-        #if defined __clang_major__ && __clang_major__ >= 12
-            #if !defined __apple_build_version__ || !__apple_build_version__
-                #define CTLL_CNTTP_COMPILER_CHECK 1
-            #endif
-        #endif
     #endif
 #endif
 

--- a/single-header/ctre.hpp
+++ b/single-header/ctre.hpp
@@ -456,12 +456,6 @@ template <size_t N> fixed_string(fixed_string<N>) -> fixed_string<N>;
 #elif defined __cpp_nontype_template_args
     #if __cpp_nontype_template_args >= 201911L
         #define CTLL_CNTTP_COMPILER_CHECK 1
-    #elif __cpp_nontype_template_args >= 201411L
-        #if defined __clang_major__ && __clang_major__ >= 12
-            #if !defined __apple_build_version__ || !__apple_build_version__
-                #define CTLL_CNTTP_COMPILER_CHECK 1
-            #endif
-        #endif
     #endif
 #endif
 


### PR DESCRIPTION
Argument deduction for a class type (like ctll::fixed_string) in a non-type template is
not supported until C++20 (201911L).

Fixes #234.