### PR TITLE
Fix incorrect UTF-16 surrogate pair conversion

### DIFF
--- a/include/ctll/fixed_string.hpp
+++ b/include/ctll/fixed_string.hpp
@@ -118,7 +118,7 @@ template <size_t N> struct fixed_string {
 				if (info.length == 2) {
 					if (++i < N) {
 						if ((input[i] & 0b1111'1100'0000'0000) == 0b1101'1100'0000'0000) {
-							content[out++] = (info.value << 10) | (input[i] & 0b0000'0011'1111'1111);
+							content[out++] = ((info.value << 10) | (input[i] & 0b0000'0011'1111'1111)) + 0x10000;
 						} else {
 							correct_flag = false;
 							break;

--- a/single-header/ctre-unicode.hpp
+++ b/single-header/ctre-unicode.hpp
@@ -353,7 +353,7 @@ template <size_t N> struct fixed_string {
 				if (info.length == 2) {
 					if (++i < N) {
 						if ((input[i] & 0b1111'1100'0000'0000) == 0b1101'1100'0000'0000) {
-							content[out++] = (info.value << 10) | (input[i] & 0b0000'0011'1111'1111);
+							content[out++] = ((info.value << 10) | (input[i] & 0b0000'0011'1111'1111)) + 0x10000;
 						} else {
 							correct_flag = false;
 							break;

--- a/single-header/ctre.hpp
+++ b/single-header/ctre.hpp
@@ -350,7 +350,7 @@ template <size_t N> struct fixed_string {
 				if (info.length == 2) {
 					if (++i < N) {
 						if ((input[i] & 0b1111'1100'0000'0000) == 0b1101'1100'0000'0000) {
-							content[out++] = (info.value << 10) | (input[i] & 0b0000'0011'1111'1111);
+							content[out++] = ((info.value << 10) | (input[i] & 0b0000'0011'1111'1111)) + 0x10000;
 						} else {
 							correct_flag = false;
 							break;

--- a/tests/_fixed-string.cpp
+++ b/tests/_fixed-string.cpp
@@ -26,6 +26,7 @@ static_assert(ctll::fixed_string(u8"😍")[0] == L'😍');
 // u"" is utf-16
 static_assert(ctll::fixed_string(u"ěšč").size() == 3);
 static_assert(ctll::fixed_string(u"😍").size() == 1);
+static_assert(ctll::fixed_string(u"😍").is_same_as(ctll::fixed_string(U"😍")));
 
 // U"" is utf-32
 static_assert(ctll::fixed_string(U"ěšč").size() == 3);


### PR DESCRIPTION
Conversion of a UTF-16 surrogate pair to the corresponding codepoint was missing the addition of 0x10000.

Fixes #236.