### PR TITLE
Add [[maybe_unused]] to suppress MSVC C4100

### DIFF
--- a/include/ctre/evaluation.hpp
+++ b/include/ctre/evaluation.hpp
@@ -20,7 +20,7 @@
 
 namespace ctre {
 
-template <size_t Limit> constexpr CTRE_FORCE_INLINE bool less_than_or_infinite(size_t i) noexcept {
+template <size_t Limit> constexpr CTRE_FORCE_INLINE bool less_than_or_infinite([[maybe_unused]] size_t i) noexcept {
 	if constexpr (Limit == 0) {
 		// infinite
 		return true;
@@ -29,7 +29,7 @@ template <size_t Limit> constexpr CTRE_FORCE_INLINE bool less_than_or_infinite(s
 	}
 }
 
-template <size_t Limit> constexpr CTRE_FORCE_INLINE bool less_than(size_t i) noexcept {
+template <size_t Limit> constexpr CTRE_FORCE_INLINE bool less_than([[maybe_unused]] size_t i) noexcept {
 	if constexpr (Limit == 0) {
 		// infinite
 		return false;

--- a/single-header/ctre-unicode.hpp
+++ b/single-header/ctre-unicode.hpp
@@ -3983,7 +3983,7 @@ template <typename... A, typename... B> constexpr bool collides(ctll::list<A...>
 
 namespace ctre {
 
-template <size_t Limit> constexpr CTRE_FORCE_INLINE bool less_than_or_infinite(size_t i) noexcept {
+template <size_t Limit> constexpr CTRE_FORCE_INLINE bool less_than_or_infinite([[maybe_unused]] size_t i) noexcept {
 	if constexpr (Limit == 0) {
 		// infinite
 		return true;
@@ -3992,7 +3992,7 @@ template <size_t Limit> constexpr CTRE_FORCE_INLINE bool less_than_or_infinite(s
 	}
 }
 
-template <size_t Limit> constexpr CTRE_FORCE_INLINE bool less_than(size_t i) noexcept {
+template <size_t Limit> constexpr CTRE_FORCE_INLINE bool less_than([[maybe_unused]] size_t i) noexcept {
 	if constexpr (Limit == 0) {
 		// infinite
 		return false;

--- a/single-header/ctre.hpp
+++ b/single-header/ctre.hpp
@@ -3980,7 +3980,7 @@ template <typename... A, typename... B> constexpr bool collides(ctll::list<A...>
 
 namespace ctre {
 
-template <size_t Limit> constexpr CTRE_FORCE_INLINE bool less_than_or_infinite(size_t i) noexcept {
+template <size_t Limit> constexpr CTRE_FORCE_INLINE bool less_than_or_infinite([[maybe_unused]] size_t i) noexcept {
 	if constexpr (Limit == 0) {
 		// infinite
 		return true;
@@ -3989,7 +3989,7 @@ template <size_t Limit> constexpr CTRE_FORCE_INLINE bool less_than_or_infinite(s
 	}
 }
 
-template <size_t Limit> constexpr CTRE_FORCE_INLINE bool less_than(size_t i) noexcept {
+template <size_t Limit> constexpr CTRE_FORCE_INLINE bool less_than([[maybe_unused]] size_t i) noexcept {
 	if constexpr (Limit == 0) {
 		// infinite
 		return false;


### PR DESCRIPTION
The warning is triggered on some old versions of MSVC