### PR TITLE
support for switching modes inside the pattern

### DIFF
--- a/include/ctre/actions/mode.inc.hpp
+++ b/include/ctre/actions/mode.inc.hpp
@@ -1,0 +1,32 @@
+#ifndef CTRE__ACTIONS__MODE__HPP
+#define CTRE__ACTIONS__MODE__HPP
+
+// we need to reset counter and wrap Mode into mode_switch
+template <typename Mode, typename... Ts, typename Parameters> static constexpr auto apply_mode(Mode, ctll::list<Ts...>, Parameters) {
+	return pcre_context<ctll::list<mode_switch<Mode>, Ts...>, Parameters>{};
+}
+
+template <typename Mode, typename... Ts, size_t Id, size_t Counter> static constexpr auto apply_mode(Mode, ctll::list<capture_id<Id>, Ts...>, pcre_parameters<Counter>) {
+	return pcre_context<ctll::list<mode_switch<Mode>, Ts...>, pcre_parameters<Counter-1>>{};
+}
+
+// catch a semantic action into mode
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::mode_case_insensitive mode, ctll::term<V>,pcre_context<ctll::list<Ts...>, Parameters>) {
+	return apply_mode(mode, ctll::list<Ts...>{}, Parameters{});
+}
+
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::mode_case_sensitive mode, ctll::term<V>,pcre_context<ctll::list<Ts...>, Parameters>) {
+	return apply_mode(mode, ctll::list<Ts...>{}, Parameters{});
+}
+
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::mode_singleline mode, ctll::term<V>,pcre_context<ctll::list<Ts...>, Parameters>) {
+	return apply_mode(mode, ctll::list<Ts...>{}, Parameters{});
+}
+
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::mode_multiline mode, ctll::term<V>,pcre_context<ctll::list<Ts...>, Parameters>) {
+	return apply_mode(mode, ctll::list<Ts...>{}, Parameters{});
+}
+
+// to properly reset capture
+
+#endif

--- a/include/ctre/atoms.hpp
+++ b/include/ctre/atoms.hpp
@@ -71,6 +71,8 @@ struct assert_subject_end_line{ };
 struct assert_line_begin { };
 struct assert_line_end { };
 
+template <typename> struct mode_switch { };
+
 }
 
 #endif

--- a/include/ctre/evaluation.hpp
+++ b/include/ctre/evaluation.hpp
@@ -550,6 +550,12 @@ constexpr CTRE_FORCE_INLINE R evaluate(const BeginIterator begin, Iterator curre
 	}
 }
 
+// switching modes
+template <typename R, typename BeginIterator, typename Iterator, typename EndIterator, typename Mode, typename... Tail> 
+constexpr CTRE_FORCE_INLINE R evaluate(const BeginIterator begin, Iterator current, const EndIterator last, const flags & f, R captures, ctll::list<mode_switch<Mode>, Tail...>) noexcept {
+	return evaluate(begin, current, last, f + Mode{}, captures, ctll::list<Tail...>());
+}
+
 
 }
 

--- a/include/ctre/flags_and_modes.hpp
+++ b/include/ctre/flags_and_modes.hpp
@@ -33,6 +33,26 @@ struct flags {
 		(this->set_flag(Args{}), ...);
 	}
 	
+	constexpr friend CTRE_FORCE_INLINE auto operator+(flags f, pcre::mode_case_insensitive) noexcept {
+		f.case_insensitive = true;
+		return f;
+	}
+	
+	constexpr friend CTRE_FORCE_INLINE auto operator+(flags f, pcre::mode_case_sensitive) noexcept {
+		f.case_insensitive = false;
+		return f;
+	}
+	
+	constexpr friend CTRE_FORCE_INLINE auto operator+(flags f, pcre::mode_singleline) noexcept {
+		f.multiline = false;
+		return f;
+	}
+	
+	constexpr friend CTRE_FORCE_INLINE auto operator+(flags f, pcre::mode_multiline) noexcept {
+		f.multiline = true;
+		return f;
+	}
+	
 	constexpr CTRE_FORCE_INLINE void set_flag(ctre::singleline) noexcept {
 		multiline = false;
 	}

--- a/include/ctre/pcre.gram
+++ b/include/ctre/pcre.gram
@@ -67,6 +67,7 @@ number2->epsilon | num,[push_number],<number2>
 preblock->open,[prepare_capture],<block>
 
 block-><content_in_capture>,[make_capture],close
+block->questionmark,<mode_switch>
 block->questionmark,angle_close,[reset_capture],[start_atomic],<content_in_capture>,[make_atomic],close
 block->questionmark,equal_sign,[reset_capture],[start_lookahead_positive],<content_in_capture>,[look_finish],close
 block->questionmark,angle_open,equal_sign,[reset_capture],[start_lookbehind_positive],<content_in_capture>,[look_finish],close
@@ -78,6 +79,11 @@ block->questionmark,angle_open,<block_name>,angle_close,<content_in_capture>,[ma
 block_name->alpha_characters,[push_name],<block_name2>
 block_name2->alphanum_characters,[push_name],<block_name2>|epsilon
 
+mode_switch->i,[mode_case_insensitive],<mode_switch2>
+mode_switch->c,[mode_case_sensitive],<mode_switch2>
+mode_switch->s,[mode_singleline],<mode_switch2>
+mode_switch->m,[mode_multiline],<mode_switch2>
+mode_switch2->close | <mode_switch>
 
 character_class->sopen,<set>,[set_make],sclose|sopen,caret,<set2a>,[set_make_negative],sclose
 set-><setitem>,[set_start],<set2b>

--- a/include/ctre/pcre.hpp
+++ b/include/ctre/pcre.hpp
@@ -33,6 +33,7 @@ struct pcre {
 	struct l {};
 	struct m {};
 	struct mod {};
+	struct mode_switch2 {};
 	struct n {};
 	struct number2 {};
 	struct number {};
@@ -92,6 +93,10 @@ struct pcre {
 	struct make_range: ctll::action {};
 	struct make_relative_back_reference: ctll::action {};
 	struct make_sequence: ctll::action {};
+	struct mode_case_insensitive: ctll::action {};
+	struct mode_case_sensitive: ctll::action {};
+	struct mode_multiline: ctll::action {};
+	struct mode_singleline: ctll::action {};
 	struct negate_class_named: ctll::action {};
 	struct prepare_capture: ctll::action {};
 	struct push_assert_begin: ctll::action {};
@@ -264,6 +269,10 @@ struct pcre {
 	static constexpr auto rule(content_in_capture, ctll::term<'\x29'>) -> ctll::push<push_empty>;
 	static constexpr auto rule(content_in_capture, ctll::set<'*','+','?','\x7B','\x7D'>) -> ctll::reject;
 
+	static constexpr auto rule(d, ctll::term<'i'>) -> ctll::push<ctll::anything, mode_case_insensitive, mode_switch2>;
+	static constexpr auto rule(d, ctll::term<'c'>) -> ctll::push<ctll::anything, mode_case_sensitive, mode_switch2>;
+	static constexpr auto rule(d, ctll::term<'m'>) -> ctll::push<ctll::anything, mode_multiline, mode_switch2>;
+	static constexpr auto rule(d, ctll::term<'s'>) -> ctll::push<ctll::anything, mode_singleline, mode_switch2>;
 	static constexpr auto rule(d, ctll::term<'<'>) -> ctll::push<ctll::anything, o>;
 	static constexpr auto rule(d, ctll::term<':'>) -> ctll::push<ctll::anything, reset_capture, content_in_capture, ctll::term<'\x29'>>;
 	static constexpr auto rule(d, ctll::term<'>'>) -> ctll::push<ctll::anything, reset_capture, start_atomic, content_in_capture, make_atomic, ctll::term<'\x29'>>;
@@ -361,6 +370,12 @@ struct pcre {
 	static constexpr auto rule(mod, ctll::term<'?'>) -> ctll::push<ctll::anything, make_lazy>;
 	static constexpr auto rule(mod, ctll::term<'+'>) -> ctll::push<ctll::anything, make_possessive>;
 	static constexpr auto rule(mod, ctll::set<'*','\x7B','\x7D'>) -> ctll::reject;
+
+	static constexpr auto rule(mode_switch2, ctll::term<'i'>) -> ctll::push<ctll::anything, mode_case_insensitive, mode_switch2>;
+	static constexpr auto rule(mode_switch2, ctll::term<'c'>) -> ctll::push<ctll::anything, mode_case_sensitive, mode_switch2>;
+	static constexpr auto rule(mode_switch2, ctll::term<'m'>) -> ctll::push<ctll::anything, mode_multiline, mode_switch2>;
+	static constexpr auto rule(mode_switch2, ctll::term<'s'>) -> ctll::push<ctll::anything, mode_singleline, mode_switch2>;
+	static constexpr auto rule(mode_switch2, ctll::term<'\x29'>) -> ctll::push<ctll::anything>;
 
 	static constexpr auto rule(n, ctll::set<'0','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, create_number, number2, repeat_ab, ctll::term<'\x7D'>, mod>;
 	static constexpr auto rule(n, ctll::term<'\x7D'>) -> ctll::push<repeat_at_least, ctll::anything, mod>;

--- a/include/ctre/pcre_actions.hpp
+++ b/include/ctre/pcre_actions.hpp
@@ -13,13 +13,16 @@ template <size_t Counter> struct pcre_parameters {
 	static constexpr size_t current_counter = Counter;
 };
 	
-template <typename Stack = ctll::list<>, typename Parameters = pcre_parameters<0>> struct pcre_context {
+template <typename Stack = ctll::list<>, typename Parameters = pcre_parameters<0>, typename Mode = ctll::list<>> struct pcre_context {
 	using stack_type = Stack;
 	using parameters_type = Parameters;
+	using mode_list = Mode;
 	static constexpr inline auto stack = stack_type();
 	static constexpr inline auto parameters = parameters_type();
+	static constexpr inline auto mode = mode_list();
 	constexpr pcre_context() noexcept { }
 	constexpr pcre_context(Stack, Parameters) noexcept { }
+	constexpr pcre_context(Stack, Parameters, Mode) noexcept { }
 };
 
 template <typename... Content, typename Parameters> pcre_context(ctll::list<Content...>, Parameters) -> pcre_context<ctll::list<Content...>, Parameters>;
@@ -46,6 +49,7 @@ struct pcre_actions {
 #include "actions/repeat.inc.hpp"
 #include "actions/sequence.inc.hpp"
 #include "actions/set.inc.hpp"
+#include "actions/mode.inc.hpp"
 
 };
 

--- a/single-header/ctre.hpp
+++ b/single-header/ctre.hpp
@@ -956,6 +956,7 @@ struct pcre {
 	struct l {};
 	struct m {};
 	struct mod {};
+	struct mode_switch2 {};
 	struct n {};
 	struct number2 {};
 	struct number {};
@@ -1015,6 +1016,10 @@ struct pcre {
 	struct make_range: ctll::action {};
 	struct make_relative_back_reference: ctll::action {};
 	struct make_sequence: ctll::action {};
+	struct mode_case_insensitive: ctll::action {};
+	struct mode_case_sensitive: ctll::action {};
+	struct mode_multiline: ctll::action {};
+	struct mode_singleline: ctll::action {};
 	struct negate_class_named: ctll::action {};
 	struct prepare_capture: ctll::action {};
 	struct push_assert_begin: ctll::action {};
@@ -1187,6 +1192,10 @@ struct pcre {
 	static constexpr auto rule(content_in_capture, ctll::term<'\x29'>) -> ctll::push<push_empty>;
 	static constexpr auto rule(content_in_capture, ctll::set<'*','+','?','\x7B','\x7D'>) -> ctll::reject;
 
+	static constexpr auto rule(d, ctll::term<'i'>) -> ctll::push<ctll::anything, mode_case_insensitive, mode_switch2>;
+	static constexpr auto rule(d, ctll::term<'c'>) -> ctll::push<ctll::anything, mode_case_sensitive, mode_switch2>;
+	static constexpr auto rule(d, ctll::term<'m'>) -> ctll::push<ctll::anything, mode_multiline, mode_switch2>;
+	static constexpr auto rule(d, ctll::term<'s'>) -> ctll::push<ctll::anything, mode_singleline, mode_switch2>;
 	static constexpr auto rule(d, ctll::term<'<'>) -> ctll::push<ctll::anything, o>;
 	static constexpr auto rule(d, ctll::term<':'>) -> ctll::push<ctll::anything, reset_capture, content_in_capture, ctll::term<'\x29'>>;
 	static constexpr auto rule(d, ctll::term<'>'>) -> ctll::push<ctll::anything, reset_capture, start_atomic, content_in_capture, make_atomic, ctll::term<'\x29'>>;
@@ -1284,6 +1293,12 @@ struct pcre {
 	static constexpr auto rule(mod, ctll::term<'?'>) -> ctll::push<ctll::anything, make_lazy>;
 	static constexpr auto rule(mod, ctll::term<'+'>) -> ctll::push<ctll::anything, make_possessive>;
 	static constexpr auto rule(mod, ctll::set<'*','\x7B','\x7D'>) -> ctll::reject;
+
+	static constexpr auto rule(mode_switch2, ctll::term<'i'>) -> ctll::push<ctll::anything, mode_case_insensitive, mode_switch2>;
+	static constexpr auto rule(mode_switch2, ctll::term<'c'>) -> ctll::push<ctll::anything, mode_case_sensitive, mode_switch2>;
+	static constexpr auto rule(mode_switch2, ctll::term<'m'>) -> ctll::push<ctll::anything, mode_multiline, mode_switch2>;
+	static constexpr auto rule(mode_switch2, ctll::term<'s'>) -> ctll::push<ctll::anything, mode_singleline, mode_switch2>;
+	static constexpr auto rule(mode_switch2, ctll::term<'\x29'>) -> ctll::push<ctll::anything>;
 
 	static constexpr auto rule(n, ctll::set<'0','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, create_number, number2, repeat_ab, ctll::term<'\x7D'>, mod>;
 	static constexpr auto rule(n, ctll::term<'\x7D'>) -> ctll::push<repeat_at_least, ctll::anything, mod>;
@@ -1431,6 +1446,26 @@ struct flags {
 	
 	template <typename... Args> constexpr CTRE_FORCE_INLINE flags(ctll::list<Args...>) noexcept {
 		(this->set_flag(Args{}), ...);
+	}
+	
+	constexpr friend CTRE_FORCE_INLINE auto operator+(flags f, pcre::mode_case_insensitive) noexcept {
+		f.case_insensitive = true;
+		return f;
+	}
+	
+	constexpr friend CTRE_FORCE_INLINE auto operator+(flags f, pcre::mode_case_sensitive) noexcept {
+		f.case_insensitive = false;
+		return f;
+	}
+	
+	constexpr friend CTRE_FORCE_INLINE auto operator+(flags f, pcre::mode_singleline) noexcept {
+		f.multiline = false;
+		return f;
+	}
+	
+	constexpr friend CTRE_FORCE_INLINE auto operator+(flags f, pcre::mode_multiline) noexcept {
+		f.multiline = true;
+		return f;
 	}
 	
 	constexpr CTRE_FORCE_INLINE void set_flag(ctre::singleline) noexcept {
@@ -1674,6 +1709,8 @@ struct assert_subject_end { };
 struct assert_subject_end_line{ };
 struct assert_line_begin { };
 struct assert_line_end { };
+
+template <typename> struct mode_switch { };
 
 }
 
@@ -2056,13 +2093,16 @@ template <size_t Counter> struct pcre_parameters {
 	static constexpr size_t current_counter = Counter;
 };
 	
-template <typename Stack = ctll::list<>, typename Parameters = pcre_parameters<0>> struct pcre_context {
+template <typename Stack = ctll::list<>, typename Parameters = pcre_parameters<0>, typename Mode = ctll::list<>> struct pcre_context {
 	using stack_type = Stack;
 	using parameters_type = Parameters;
+	using mode_list = Mode;
 	static constexpr inline auto stack = stack_type();
 	static constexpr inline auto parameters = parameters_type();
+	static constexpr inline auto mode = mode_list();
 	constexpr pcre_context() noexcept { }
 	constexpr pcre_context(Stack, Parameters) noexcept { }
+	constexpr pcre_context(Stack, Parameters, Mode) noexcept { }
 };
 
 template <typename... Content, typename Parameters> pcre_context(ctll::list<Content...>, Parameters) -> pcre_context<ctll::list<Content...>, Parameters>;
@@ -2846,6 +2886,39 @@ template <auto V, typename A, typename... Ts, typename Parameters> static conste
 template <auto V, auto B, auto A, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_range, ctll::term<V>, pcre_context<ctll::list<character<B>,character<A>, Ts...>, Parameters> subject) {
 	return pcre_context{ctll::push_front(char_range<A,B>(), ctll::list<Ts...>()), subject.parameters};
 }
+
+#endif
+
+#ifndef CTRE__ACTIONS__MODE__HPP
+#define CTRE__ACTIONS__MODE__HPP
+
+// we need to reset counter and wrap Mode into mode_switch
+template <typename Mode, typename... Ts, typename Parameters> static constexpr auto apply_mode(Mode, ctll::list<Ts...>, Parameters) {
+	return pcre_context<ctll::list<mode_switch<Mode>, Ts...>, Parameters>{};
+}
+
+template <typename Mode, typename... Ts, size_t Id, size_t Counter> static constexpr auto apply_mode(Mode, ctll::list<capture_id<Id>, Ts...>, pcre_parameters<Counter>) {
+	return pcre_context<ctll::list<mode_switch<Mode>, Ts...>, pcre_parameters<Counter-1>>{};
+}
+
+// catch a semantic action into mode
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::mode_case_insensitive mode, ctll::term<V>,pcre_context<ctll::list<Ts...>, Parameters>) {
+	return apply_mode(mode, ctll::list<Ts...>{}, Parameters{});
+}
+
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::mode_case_sensitive mode, ctll::term<V>,pcre_context<ctll::list<Ts...>, Parameters>) {
+	return apply_mode(mode, ctll::list<Ts...>{}, Parameters{});
+}
+
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::mode_singleline mode, ctll::term<V>,pcre_context<ctll::list<Ts...>, Parameters>) {
+	return apply_mode(mode, ctll::list<Ts...>{}, Parameters{});
+}
+
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::mode_multiline mode, ctll::term<V>,pcre_context<ctll::list<Ts...>, Parameters>) {
+	return apply_mode(mode, ctll::list<Ts...>{}, Parameters{});
+}
+
+// to properly reset capture
 
 #endif
 
@@ -4763,6 +4836,12 @@ constexpr CTRE_FORCE_INLINE R evaluate(const BeginIterator begin, Iterator curre
 	} else {
 		return evaluate(begin, current, last, f, captures, ctll::list<Tail...>());
 	}
+}
+
+// switching modes
+template <typename R, typename BeginIterator, typename Iterator, typename EndIterator, typename Mode, typename... Tail> 
+constexpr CTRE_FORCE_INLINE R evaluate(const BeginIterator begin, Iterator current, const EndIterator last, const flags & f, R captures, ctll::list<mode_switch<Mode>, Tail...>) noexcept {
+	return evaluate(begin, current, last, f + Mode{}, captures, ctll::list<Tail...>());
 }
 
 }

--- a/tests/matching3.cpp
+++ b/tests/matching3.cpp
@@ -203,8 +203,9 @@ TEST_MATCH(118, "^(\\w+)", "WORD");
 TEST_MATCH(203, "(?=foo)foo", "foo");
 TEST_MATCH(204, "(?!notfoo)foo", "foo");
 
-// TODO reverse content of lookbehind
 TEST_MATCH(205, "ab(?<=ab)foo", "abfoo");
 TEST_MATCH(206, "ab(?<!foo)foo", "abfoo");
 
+// modes
+TEST_MATCH(207, "(?i)AB(?c)AB", "abAB");
 

--- a/tests/mode.cpp
+++ b/tests/mode.cpp
@@ -1,0 +1,44 @@
+#include <ctre.hpp>
+
+void empty_symbol() { }
+
+using namespace ctre::test_literals;
+
+#if !CTRE_CNTTP_COMPILER_CHECK
+#define CTRE_TEST(pattern) (pattern ## _ctre_test)
+#else
+
+template <typename...> struct identify_me;
+
+template <ctll::fixed_string input> constexpr bool test() {
+	constexpr auto _input = input;
+
+	using tmp = typename ctll::parser<ctre::pcre, _input, ctre::pcre_actions>::template output<ctre::pcre_context<>>;
+	//static_assert(tmp(), "Regular Expression contains syntax error.");
+	//using re = decltype(front(typename tmp::output_type::stack_type()));
+	//identify_me<typename tmp::output_type::stack_type> i;
+	////return ctre::regular_expression(re());
+	return tmp();
+}
+
+#define CTRE_TEST(pattern) test<pattern>()
+#endif
+
+
+// basics
+static_assert(!CTRE_TEST("(?)"));
+static_assert(CTRE_TEST("(?i)"));
+static_assert(CTRE_TEST("(?ic)"));
+static_assert(CTRE_TEST("(?icsm)"));
+
+// after
+static_assert(CTRE_TEST("(?i)x"));
+static_assert(CTRE_TEST("(?ic)x"));
+static_assert(CTRE_TEST("(?icsm)x"));
+
+// before
+static_assert(CTRE_TEST("y(?i)"));
+static_assert(CTRE_TEST("y(?ic)"));
+static_assert(CTRE_TEST("y(?icsm)"));
+
+


### PR DESCRIPTION
for now supported switches:

(?i) ... case insensitive
(?c) ... case sensitive
(?s) ... singleline
(?m) ... multiline