### PR TITLE
Fix building of utf8.hpp on clang-10 / libstdc++-8

### DIFF
--- a/include/ctre/utf8.hpp
+++ b/include/ctre/utf8.hpp
@@ -7,6 +7,10 @@
 #include <string_view>
 #include <iterator>
 
+#if __cpp_lib_char8_t >= 201811L
+#define CTRE_ENABLE_UTF8_RANGE
+#endif
+
 namespace ctre {
 
 struct utf8_iterator {
@@ -188,6 +192,7 @@ struct utf8_iterator {
 	}
 };
 
+#ifdef CTRE_ENABLE_UTF8_RANGE
 struct utf8_range {
 	std::u8string_view range;
 	constexpr utf8_range(std::u8string_view r) noexcept: range{r} { }
@@ -199,6 +204,7 @@ struct utf8_range {
 		return utf8_iterator::sentinel{};
 	}
 };
+#endif
 
 }
 

--- a/include/ctre/wrapper.hpp
+++ b/include/ctre/wrapper.hpp
@@ -184,7 +184,7 @@ template <typename RE, typename Method, typename Modifier> struct regular_expres
 	static constexpr CTRE_FORCE_INLINE auto exec(std::wstring_view sv) noexcept {
 		return exec(sv.begin(), sv.end());
 	}
-#if __cpp_char8_t >= 201811
+#ifdef CTRE_ENABLE_UTF8_RANGE
 	static constexpr CTRE_FORCE_INLINE auto exec(std::u8string_view sv) noexcept {
 		return exec_with_result_iterator<const char8_t *>(utf8_range(sv).begin(), utf8_range(sv).end());
 	}

--- a/single-header/ctre-unicode.hpp
+++ b/single-header/ctre-unicode.hpp
@@ -3031,6 +3031,10 @@ constexpr bool starts_with_anchor(const flags & f, ctll::list<capture_with_name<
 #include <string_view>
 #include <iterator>
 
+#if __cpp_lib_char8_t >= 201811L
+#define CTRE_ENABLE_UTF8_RANGE
+#endif
+
 namespace ctre {
 
 struct utf8_iterator {
@@ -3212,6 +3216,7 @@ struct utf8_iterator {
 	}
 };
 
+#ifdef CTRE_ENABLE_UTF8_RANGE
 struct utf8_range {
 	std::u8string_view range;
 	constexpr utf8_range(std::u8string_view r) noexcept: range{r} { }
@@ -3223,12 +3228,14 @@ struct utf8_range {
 		return utf8_iterator::sentinel{};
 	}
 };
+#endif
 
 }
 
 #endif
 
 #endif
+
 #include <type_traits>
 #include <tuple>
 #include <string_view>
@@ -5377,7 +5384,7 @@ template <typename RE, typename Method, typename Modifier> struct regular_expres
 	static constexpr CTRE_FORCE_INLINE auto exec(std::wstring_view sv) noexcept {
 		return exec(sv.begin(), sv.end());
 	}
-#if __cpp_char8_t >= 201811
+#ifdef CTRE_ENABLE_UTF8_RANGE
 	static constexpr CTRE_FORCE_INLINE auto exec(std::u8string_view sv) noexcept {
 		return exec_with_result_iterator<const char8_t *>(utf8_range(sv).begin(), utf8_range(sv).end());
 	}

--- a/single-header/ctre.hpp
+++ b/single-header/ctre.hpp
@@ -3028,6 +3028,10 @@ constexpr bool starts_with_anchor(const flags & f, ctll::list<capture_with_name<
 #include <string_view>
 #include <iterator>
 
+#if __cpp_lib_char8_t >= 201811L
+#define CTRE_ENABLE_UTF8_RANGE
+#endif
+
 namespace ctre {
 
 struct utf8_iterator {
@@ -3209,6 +3213,7 @@ struct utf8_iterator {
 	}
 };
 
+#ifdef CTRE_ENABLE_UTF8_RANGE
 struct utf8_range {
 	std::u8string_view range;
 	constexpr utf8_range(std::u8string_view r) noexcept: range{r} { }
@@ -3220,12 +3225,14 @@ struct utf8_range {
 		return utf8_iterator::sentinel{};
 	}
 };
+#endif
 
 }
 
 #endif
 
 #endif
+
 #include <type_traits>
 #include <tuple>
 #include <string_view>
@@ -5374,7 +5381,7 @@ template <typename RE, typename Method, typename Modifier> struct regular_expres
 	static constexpr CTRE_FORCE_INLINE auto exec(std::wstring_view sv) noexcept {
 		return exec(sv.begin(), sv.end());
 	}
-#if __cpp_char8_t >= 201811
+#ifdef CTRE_ENABLE_UTF8_RANGE
 	static constexpr CTRE_FORCE_INLINE auto exec(std::u8string_view sv) noexcept {
 		return exec_with_result_iterator<const char8_t *>(utf8_range(sv).begin(), utf8_range(sv).end());
 	}

--- a/tests/__utf8.cpp
+++ b/tests/__utf8.cpp
@@ -1,7 +1,7 @@
 #include <ctre/utf8.hpp>
 #include <algorithm>
 
-#if __cpp_char8_t >= 201811
+#ifdef CTRE_ENABLE_UTF8_RANGE
 
 #define UNICODE_TEST(a) static_assert(call_test(u8 ##a, U ##a))
 


### PR DESCRIPTION
e.g. on Ubuntu 18.04: __cpp_char8_t is indeed >= 201811 as clang-10 already supports a C++20 mode with char8_t, but it uses by default libstdc++'s standard library there which did not provide std::u8string_view at this time