### PR TITLE
support stdlib without support for wchar_t

### DIFF
--- a/include/ctll/fixed_string.hpp
+++ b/include/ctll/fixed_string.hpp
@@ -6,6 +6,8 @@
 #include <string_view>
 #include <cstdint>
 
+#include "utilities.hpp"
+
 namespace ctll {
 
 struct length_value_t {
@@ -130,12 +132,14 @@ template <size_t N> struct fixed_string {
 				}
 			}
 			real_size = out;
+#ifndef CTLL_NO_WCHAR_T
 		} else if constexpr (std::is_same_v<T, wchar_t> || std::is_same_v<T, char32_t>) {
 			for (size_t i{0}; i < N; ++i) {
-				content[i] = static_cast<char32_t>(input[i]);
-				if ((i == (N-1)) && (input[i] == 0)) break;
-				real_size++;
-			}
+                content[i] = static_cast<char32_t>(input[i]);
+                if ((i == (N - 1)) && (input[i] == 0)) break;
+                real_size++;
+            }
+#endif
 		}
 	}
 	constexpr fixed_string(const fixed_string & other) noexcept {

--- a/include/ctll/utilities.hpp
+++ b/include/ctll/utilities.hpp
@@ -40,6 +40,13 @@
 #define CTLL_FORCE_INLINE __attribute__((always_inline))
 #endif
 
+#ifdef _LIBCPP_VERSION
+#ifdef _LIBCPP_HAS_NO_WIDE_CHARACTERS
+#define CTLL_NO_WCHAR_T
+#else
+#endif
+#endif
+
 namespace ctll {
 	
 template <bool> struct conditional_helper;

--- a/include/ctre/utility.hpp
+++ b/include/ctre/utility.hpp
@@ -4,6 +4,9 @@
 #include "../ctll/utilities.hpp"
 
 #define CTRE_CNTTP_COMPILER_CHECK CTLL_CNTTP_COMPILER_CHECK
+#ifdef CTLL_NO_WCHAR_T
+#define CTRE_NO_WCHAR_T
+#endif
 
 #if __GNUC__ > 9
 #if __has_cpp_attribute(likely)

--- a/include/ctre/wrapper.hpp
+++ b/include/ctre/wrapper.hpp
@@ -32,27 +32,29 @@ struct zero_terminated_string_end_iterator {
 	constexpr CTRE_FORCE_INLINE friend bool operator==(const char * ptr, zero_terminated_string_end_iterator) noexcept {
 		return *ptr == '\0';
 	} 
-	constexpr CTRE_FORCE_INLINE friend bool operator==(const wchar_t * ptr, zero_terminated_string_end_iterator) noexcept {
+    constexpr CTRE_FORCE_INLINE friend bool operator!=(const char * ptr, zero_terminated_string_end_iterator) noexcept {
+        return *ptr != '\0';
+    }
+    constexpr CTRE_FORCE_INLINE friend bool operator==(zero_terminated_string_end_iterator, const char * ptr) noexcept {
+        return *ptr == '\0';
+    }
+    constexpr CTRE_FORCE_INLINE friend bool operator!=(zero_terminated_string_end_iterator, const char * ptr) noexcept {
+        return *ptr != '\0';
+    }
+#ifndef CTLL_NO_WCHAR_T
+    constexpr CTRE_FORCE_INLINE friend bool operator==(const wchar_t * ptr, zero_terminated_string_end_iterator) noexcept {
 		return *ptr == 0;
-	} 
-	constexpr CTRE_FORCE_INLINE friend bool operator!=(const char * ptr, zero_terminated_string_end_iterator) noexcept {
-		return *ptr != '\0';
 	} 
 	constexpr CTRE_FORCE_INLINE friend bool operator!=(const wchar_t * ptr, zero_terminated_string_end_iterator) noexcept {
 		return *ptr != 0;
-	} 
-	constexpr CTRE_FORCE_INLINE friend bool operator==(zero_terminated_string_end_iterator, const char * ptr) noexcept {
-		return *ptr == '\0';
-	} 
-	constexpr CTRE_FORCE_INLINE friend bool operator==(zero_terminated_string_end_iterator, const wchar_t * ptr) noexcept {
-		return *ptr == 0;
-	} 
-	constexpr CTRE_FORCE_INLINE friend bool operator!=(zero_terminated_string_end_iterator, const char * ptr) noexcept {
-		return *ptr != '\0';
-	} 
-	constexpr CTRE_FORCE_INLINE friend bool operator!=(zero_terminated_string_end_iterator, const wchar_t * ptr) noexcept {
-		return *ptr != 0;
-	} 
+	}
+    constexpr CTRE_FORCE_INLINE friend bool operator==(zero_terminated_string_end_iterator, const wchar_t * ptr) noexcept {
+        return *ptr == 0;
+    }
+    constexpr CTRE_FORCE_INLINE friend bool operator!=(zero_terminated_string_end_iterator, const wchar_t * ptr) noexcept {
+        return *ptr != 0;
+    }
+#endif
 };
 
 template <typename T> class RangeLikeType {
@@ -181,9 +183,11 @@ template <typename RE, typename Method, typename Modifier> struct regular_expres
 	static constexpr CTRE_FORCE_INLINE auto exec(std::string_view sv) noexcept {
 		return exec(sv.begin(), sv.end());
 	}
+#ifndef CTRE_NO_WCHAR_T
 	static constexpr CTRE_FORCE_INLINE auto exec(std::wstring_view sv) noexcept {
 		return exec(sv.begin(), sv.end());
 	}
+#endif
 #ifdef CTRE_ENABLE_UTF8_RANGE
 	static constexpr CTRE_FORCE_INLINE auto exec(std::u8string_view sv) noexcept {
 		return exec_with_result_iterator<const char8_t *>(utf8_range(sv).begin(), utf8_range(sv).end());


### PR DESCRIPTION
On my embedded environment (https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm), there is no support for `wchar_t`. This PR adds preprocessor guards excluding code that refers to wide characters and strings. That guard is automatically applied when `libc++` is detected and it indicates that itself has been compiled without support for wide characters. 