### PR TITLE
🛠 Fix Clang not knowing what bizarre attributes MSVC will cook up

### DIFF
--- a/include/ctre/utility.hpp
+++ b/include/ctre/utility.hpp
@@ -24,7 +24,9 @@
 
 #ifdef _MSC_VER
 #define CTRE_FORCE_INLINE __forceinline
-#if _MSC_VER >= 1930
+#if __has_cpp_attribute(msvc::flatten)
+#define CTRE_FLATTEN [[msvc::flatten]]
+#elif _MSC_VER >= 1930 && !defined(__clang__)
 #define CTRE_FLATTEN [[msvc::flatten]]
 #else
 #define CTRE_FLATTEN


### PR DESCRIPTION
ℹ This prevents errors on clang and clang-cl on Windows.