### PR TITLE
Fix Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ ctre::match<"REGEX">(subject); // C++20
 * Searching (`search` or `starts_with`)
 * Capturing content (named captures are supported too, but only with syntax `(?<name>...)`)
 * Back-Reference (\g{N} syntax, and \1...\9 syntax too)
-* Multiline support (with `multi_`) functions
+* Multiline support (with `multiline_`) functions
 * Unicode properties and UTF-8 support
 
 The library is implementing most of the PCRE syntax with a few exceptions:
@@ -248,9 +248,8 @@ This support is preliminary, probably the API will be changed.
 ```c++
 auto input = "123,456,768"sv;
 
-for (auto match: ctre::range<"([0-9]+),?">(input)) {
+for (auto match: ctre::search_all<"([0-9]+),?">(input))
     std::cout << std::string_view{match.get<0>()} << "\n";
-}
 ```
 
 ### Unicode
@@ -258,16 +257,17 @@ for (auto match: ctre::range<"([0-9]+),?">(input)) {
 ```c++
 #include <ctre-unicode.hpp>
 #include <iostream>
+
 // needed if you want to output to the terminal
 std::string_view cast_from_unicode(std::u8string_view input) noexcept {
     return std::string_view(reinterpret_cast<const char *>(input.data()), input.size());
 }
-int main()
-{
+
+int main() {
     using namespace std::literals;
     std::u8string_view original = u8"Tu es un génie"sv;
 
-    for (auto match : ctre::range<"\\p{Letter}+">(original))
+    for (auto match : ctre::search_all<"\\p{Letter}+">(original))
         std::cout << cast_from_unicode(match) << std::endl;
     return 0;
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Compile time regular expressions v3
+# Compile Time Regular Expressions v3
 
 [![Build Status](https://travis-ci.org/hanickadot/compile-time-regular-expressions.svg?branch=master)](https://travis-ci.org/hanickadot/compile-time-regular-expressions)
 
@@ -18,7 +18,7 @@ ctre::match<"REGEX">(subject); // C++20
 * Matching
 * Searching (`search` or `starts_with`)
 * Capturing content (named captures are supported too, but only with syntax `(?<name>...)`)
-* Back-Reference (\g{N} syntax, and \1...\9 syntax too)
+* Back-Reference (`\g{N}` syntax, and `\1...\9` syntax too)
 * Multiline support (with `multiline_`) functions
 * Unicode properties and UTF-8 support
 
@@ -76,10 +76,10 @@ template <...> struct regex_results {
 };
 ```
 
-### Range outputing API
+### Range outputting API
 
 ```c++
-// search for regex in input and return each occurence, ignoring rest:
+// search for regex in input and return each occurrence, ignoring rest:
 template <fixed_string regex> auto ctre::range(auto Range &&) -> range of regex_result;
 template <fixed_string regex> auto ctre::range(auto First &&, auto Last &&) -> range of regex_result;
 
@@ -87,7 +87,7 @@ template <fixed_string regex> auto ctre::range(auto First &&, auto Last &&) -> r
 template <fixed_string regex> auto ctre::tokenize(auto Range &&) -> range of regex_result;
 template <fixed_string regex> auto ctre::tokenize(auto First &&, auto Last &&) -> range of regex_result;
 
-// return parts of the input splited by the regex, returning it as part of content of the implicit zero capture (other captures are not changed, you can use it to access how the values were splitted):
+// return parts of the input split by the regex, returning it as part of content of the implicit zero capture (other captures are not changed, you can use it to access how the values were split):
 template <fixed_string regex> auto ctre::split(auto Range &&) -> regex_result;
 template <fixed_string regex> auto ctre::split(auto First &&, auto Last &&) -> range of regex_result;
 ```
@@ -109,6 +109,7 @@ if (matcher(input)) ...
 ### Unicode support
 
 To enable you need to include:
+
 * `<ctre-unicode.hpp>`
 * or `<ctre.hpp>` and `<unicode-db.hpp>`
 
@@ -190,10 +191,10 @@ std::optional<date> extract_date(std::string_view s) noexcept {
     }
 }
 
-//static_assert(extract_date("2018/08/27"sv).has_value());
-//static_assert((*extract_date("2018/08/27"sv)).year == "2018"sv);
-//static_assert((*extract_date("2018/08/27"sv)).month == "08"sv);
-//static_assert((*extract_date("2018/08/27"sv)).day == "27"sv);
+// static_assert(extract_date("2018/08/27"sv).has_value());
+// static_assert((*extract_date("2018/08/27"sv)).year == "2018"sv);
+// static_assert((*extract_date("2018/08/27"sv)).month == "08"sv);
+// static_assert((*extract_date("2018/08/27"sv)).day == "27"sv);
 ```
 
 [link to compiler explorer](https://gcc.godbolt.org/z/x64CVp)

--- a/README.md
+++ b/README.md
@@ -208,11 +208,11 @@ return date{result.get<"year">(), result.get<"month">, result.get<"day">};
 static constexpr ctll::fixed_string year = "year";
 static constexpr ctll::fixed_string month = "month";
 static constexpr ctll::fixed_string day = "day";
-return date{result.get<year>(), result.get<month>, result.get<day>};
+return date{result.get<year>(), result.get<month>(), result.get<day>()};
 
 // or use numbered access
 // capture 0 is the whole match
-return date{result.get<1>(), result.get<2>, result.get<3>};
+return date{result.get<1>(), result.get<2>(), result.get<3>()};
 ```
 
 ### Lexer


### PR DESCRIPTION
@hanickadot, thank you for a great project! I've heard about it for years and finally got the chance to try it 🤗 

I was looking to implement a RegEx-based parser for my [`less_slow.cpp` tutorial](https://github.com/ashvardanian/less_slow.cpp), where I need to find all matches of a multi-line pattern in a byte-string. I've noticed, that some of the aspects of the documentation were outdated, and @bortsov has opened a related issue with a proposed patch.

---

I've also noticed an issue with an end-of-line symbol, but haven't localized the issue yet. Here is what my usage pattern looks like:

```cpp
void config_parse_ctre(std::string_view config_text, std::vector<std::pair<std::string, std::string>> &settings) {
    for (auto match : ctre::multiline_search_all<R"(^\s*([^#:\s]+)\s*:\s*([^#:\s]+)\s*$)">(config_text)) {
        std::string_view key = match.get<1>().to_view();
        std::string_view value = match.get<2>().to_view();
        settings.emplace_back(key, value);
    }
}
```

This RagEx pattern works fine with `std::regex`, but `ctre::` seems to have troubles with the dollar sign in the end. Please let me know if you have any ideas, or if I should open an issue.