### PR TITLE
Cast ranges to the character type

### DIFF
--- a/include/ctre/atoms_characters.hpp
+++ b/include/ctre/atoms_characters.hpp
@@ -79,7 +79,7 @@ template <auto A, auto B> struct char_range {
 				}
 			}	
 		}
-		return (value >= A) && (value <= B);
+		return (value >= (CharT)A) && (value <= (CharT)B);
 	}
 };
 using word_chars = set<char_range<'A','Z'>, char_range<'a','z'>, char_range<'0','9'>, character<'_'> >;


### PR DESCRIPTION
Fixes #330

Fixes \x80-\xFF not matching high-ascii bytes
```c++
#include <ctre.hpp>
#include <regex>
#include <iostream>

int main()
{
    const char * b = "knäckebröd";

    auto k = ctre::search<R"([\x00-\x7F\x80-\xFF]*)">(b);
    std::cout << k.get<0>().to_view() << std::endl;

    auto k2 = ctre::search<R"(.*)">(b);
    std::cout << k2.get<0>().to_view() << std::endl;

    std::regex r{R"([\x00-\x7F\x80-\xFF]*)"};
    std::cmatch m;
    std::regex_search(b, m, r);
    std::cout << m[0] << std::endl;
}
```
https://godbolt.org/z/h4vxWajxb