### PR TITLE
Add support for leading `-` in character sets

### DIFF
--- a/include/ctre/pcre.gram
+++ b/include/ctre/pcre.gram
@@ -87,7 +87,7 @@ mode_switch->s,[mode_singleline],<mode_switch2>
 mode_switch->m,[mode_multiline],<mode_switch2>
 mode_switch2->close | <mode_switch>
 
-character_class->sopen,<set>,[set_make],sclose|sopen,caret,<set2a>,[set_make_negative],sclose
+character_class->sopen,<set>,[set_make],sclose|sopen,minus,<set>,[set_make],sclose|sopen,caret,<set2a>,[set_make_negative],sclose
 set-><setitem>,[set_start],<set2b>
 set2a-><setitem2>,[set_start],<set2b>|epsilon,[set_empty]
 set2b-><setitem2>,[set_combine],<set2b>|epsilon

--- a/include/ctre/pcre.hpp
+++ b/include/ctre/pcre.hpp
@@ -234,7 +234,8 @@ struct pcre {
 	static constexpr auto rule(c, ctll::set<'!','$','\x28','\x29','*','+',',','.','/','0','1','2','3','4','5','6','7','8','9',':','<','=','>','?','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','\"','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','\x7B','|','\x7D'>) -> ctll::push<ctll::anything, push_character, range, set_start, set2b, set_make, ctll::term<']'>>;
 	static constexpr auto rule(c, _others) -> ctll::push<ctll::anything, push_character, range, set_start, set2b, set_make, ctll::term<']'>>;
 	static constexpr auto rule(c, ctll::term<'^'>) -> ctll::push<ctll::anything, set2a, set_make_negative, ctll::term<']'>>;
-	static constexpr auto rule(c, ctll::set<'-',']'>) -> ctll::reject;
+	static constexpr auto rule(c, ctll::term<'-'>) -> ctll::push<ctll::anything, push_character, set_start, set2b, set_make, ctll::term<']'>>;
+	static constexpr auto rule(c, ctll::term<']'>) -> ctll::reject;
 
 	static constexpr auto rule(class_named_name, ctll::term<'x'>) -> ctll::push<ctll::anything, ctll::term<'d'>, ctll::term<'i'>, ctll::term<'g'>, ctll::term<'i'>, ctll::term<'t'>, class_named_xdigit>;
 	static constexpr auto rule(class_named_name, ctll::term<'d'>) -> ctll::push<ctll::anything, ctll::term<'i'>, ctll::term<'g'>, ctll::term<'i'>, ctll::term<'t'>, class_named_digit>;

--- a/single-header/ctre.hpp
+++ b/single-header/ctre.hpp
@@ -1176,7 +1176,8 @@ struct pcre {
 	static constexpr auto rule(c, ctll::set<'!','$','\x28','\x29','*','+',',','.','/','0','1','2','3','4','5','6','7','8','9',':','<','=','>','?','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','\"','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','\x7B','|','\x7D'>) -> ctll::push<ctll::anything, push_character, range, set_start, set2b, set_make, ctll::term<']'>>;
 	static constexpr auto rule(c, _others) -> ctll::push<ctll::anything, push_character, range, set_start, set2b, set_make, ctll::term<']'>>;
 	static constexpr auto rule(c, ctll::term<'^'>) -> ctll::push<ctll::anything, set2a, set_make_negative, ctll::term<']'>>;
-	static constexpr auto rule(c, ctll::set<'-',']'>) -> ctll::reject;
+	static constexpr auto rule(c, ctll::term<'-'>) -> ctll::push<ctll::anything, push_character, set_start, set2b, set_make, ctll::term<']'>>;
+	static constexpr auto rule(c, ctll::term<']'>) -> ctll::reject;
 
 	static constexpr auto rule(class_named_name, ctll::term<'x'>) -> ctll::push<ctll::anything, ctll::term<'d'>, ctll::term<'i'>, ctll::term<'g'>, ctll::term<'i'>, ctll::term<'t'>, class_named_xdigit>;
 	static constexpr auto rule(class_named_name, ctll::term<'d'>) -> ctll::push<ctll::anything, ctll::term<'i'>, ctll::term<'g'>, ctll::term<'i'>, ctll::term<'t'>, class_named_digit>;

--- a/tests/matching3.cpp
+++ b/tests/matching3.cpp
@@ -246,3 +246,7 @@ TEST_NOT_MATCH(233, "[^]", "");
 TEST_MATCH(234, "[^]+", "x");
 TEST_MATCH(235, "[^]?", "");
 
+// issue #346
+TEST_MATCH(236, "[-A-Z]?", "Hello-World");
+TEST_NOT_MATCH(237, "[A-Z]?", "Hello-World");
+TEST_MATCH(238, "[\\-A-Z]?", "Hello-World");


### PR DESCRIPTION
This adds support for leading unescaped `-` in sets, since that's trivial to do manually without access to desatomat. Adding support for trailing unescaped `-` without access to desatomat is dramatically harder, so I have no done that.

The actual code generated by desatomat will likely differ slightly from what I'm doing manually here, but the result should still be the same.

This is a partial fix for https://github.com/hanickadot/compile-time-regular-expressions/issues/346. Support for trailing unescaped `-` is likely trivial with access to desomat, but I don't appear to have access to that, and the web version times out, so I can't do that bit myself :(