### PR TITLE
Added the + operator to ctll::fixed_string to enable compile time concatenation. 

### DIFF
--- a/include/ctll/fixed_string.hpp
+++ b/include/ctll/fixed_string.hpp
@@ -218,6 +218,26 @@ template <typename CharT, size_t N> fixed_string(const std::array<CharT,N> &) ->
 
 template <size_t N> fixed_string(fixed_string<N>) -> fixed_string<N>;
 
+CTLL_EXPORT template <size_t A, size_t B>
+constexpr auto operator+(const fixed_string<A> & l, const fixed_string<B> & r) noexcept {
+	if constexpr ((A + B) > 0) {
+		char32_t content[A + B]{};
+		size_t i{0};
+		for (size_t j{0}; j < l.size(); ++j) {
+			content[i++] = l[j];
+		}
+		for (size_t j{0}; j < r.size(); ++j) {
+			content[i++] = r[j];
+		}
+		fixed_string<A + B> out(construct_from_pointer, content);
+		out.real_size = l.size() + r.size();
+		out.correct_flag = l.correct() && r.correct();
+		return out;
+	} else {
+		return fixed_string<0>{""};
+	}
+}
+
 }
 
 #endif

--- a/tests/string.cpp
+++ b/tests/string.cpp
@@ -1,11 +1,11 @@
 #include <ctll/fixed_string.hpp>
 
-constexpr auto a = ctll::fixed_string{"\0\0"};
+constexpr auto a = ctll::fixed_string{"\0\1"};
 
 static_assert(a.correct());
 static_assert(a.size() == 2u);
 
-constexpr auto b = ctll::fixed_string{"\0"};
+constexpr auto b = ctll::fixed_string{"\2"};
 
 static_assert(b.correct());
 static_assert(b.size() == 1u);
@@ -14,3 +14,70 @@ constexpr auto c = ctll::fixed_string{""};
 
 static_assert(c.correct());
 static_assert(c.size() == 0u);
+
+
+
+constexpr auto a_b = a + b;
+static_assert(a_b.correct());
+static_assert(a_b.size() == 3u);
+static_assert(a_b[0] == U'\0');
+static_assert(a_b[1] == U'\1');
+static_assert(a_b[2] == U'\2');
+
+constexpr auto empty = ctll::fixed_string{""};
+
+constexpr auto empty_empty = empty + empty;
+static_assert(empty_empty.correct());
+static_assert(empty_empty.size() == 0u);
+
+constexpr auto empty_a = empty + a;
+static_assert(empty_a.correct());
+static_assert(empty_a.size() == 2u);
+static_assert(empty_a.is_same_as(a));
+
+constexpr auto a_empty = a + empty;
+static_assert(a_empty.correct());
+static_assert(a_empty.size() == 2u);
+static_assert(a_empty.is_same_as(a));
+
+constexpr auto hello = ctll::fixed_string{"hello"};
+constexpr auto world = ctll::fixed_string{" world"};
+constexpr auto hello_world = hello + world;
+static_assert(hello_world.correct());
+static_assert(hello_world.size() == 11u);
+static_assert(hello_world.is_same_as(ctll::fixed_string{"hello world"}));
+
+#if __cpp_char8_t
+constexpr auto u8_left = ctll::fixed_string{u8"€"};
+constexpr auto u8_right = ctll::fixed_string{u8"a"};
+constexpr auto u8_concat = u8_left + u8_right;
+static_assert(u8_concat.correct());
+static_assert(u8_concat.size() == 2u);
+static_assert(u8_concat.is_same_as(ctll::fixed_string{u8"€a"}));
+#endif
+
+constexpr auto u16_left = ctll::fixed_string{u"€"};
+constexpr auto u16_right = ctll::fixed_string{u"a"};
+constexpr auto u16_concat = u16_left + u16_right;
+static_assert(u16_concat.correct());
+static_assert(u16_concat.size() == 2u);
+static_assert(u16_concat.is_same_as(ctll::fixed_string{u"€a"}));
+
+constexpr auto u32_left = ctll::fixed_string{U"€"};
+constexpr auto u32_right = ctll::fixed_string{U"a"};
+constexpr auto u32_concat = u32_left + u32_right;
+static_assert(u32_concat.correct());
+static_assert(u32_concat.size() == 2u);
+static_assert(u32_concat.is_same_as(ctll::fixed_string{U"€a"}));
+
+#if __cpp_char8_t
+constexpr auto u8_invalid = ctll::fixed_string{u8"\x80"};
+static_assert(!u8_invalid.correct());
+static_assert(!(u8_invalid + u8_left).correct());
+static_assert(!(u8_left + u8_invalid).correct());
+#endif
+
+constexpr auto u16_invalid = ctll::fixed_string{u"\xD800 "};
+static_assert(!u16_invalid.correct());
+static_assert(!(u16_invalid + u16_left).correct());
+static_assert(!(u16_left + u16_invalid).correct());


### PR DESCRIPTION
Hello,

Thanks for this great library! 

I had a use case where being able to construct the fixed string based on the value of a template parameter (where the majority of the regex was the same) would have been useful. A dummy example is bellow:


```
#include <string_view>
#include <ctre.hpp>

template<bool AllowMultipleSpaces>
constexpr bool matches(std::string_view const str) {
    constexpr  auto regex = []()  {
        constexpr auto START = ctll::fixed_string("hello");
        constexpr auto END = ctll::fixed_string("world");
        if constexpr (AllowMultipleSpaces) {
            return START + ctll::fixed_string("[ ]+") + END;
        } else {
            return START + ctll::fixed_string(" ") + END;
        }
    }();
    return ctre::match<regex>(str);
}
```

This PR enables the `+` operator which allows this to be done. 

I completely understand if this isn't something you want bloating `ctll`!
